### PR TITLE
[WIP] Menu widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ floating_button = ["button"]
 glow = [] # TODO
 icon_text = []
 icons = []
+menu = ["icon_text"]
 modal = []
 tab_bar = []
 tabs = ["tab_bar"]
@@ -34,6 +35,7 @@ default = [
     "date_picker",
     "color_picker",
     "floating_button",
+    "menu",
     "modal",
     "tab_bar",
     "tabs",
@@ -65,6 +67,7 @@ members = [
     "examples/color_picker",
     "examples/date_picker",
     "examples/floating_button",
+    "examples/menu",
     "examples/modal",
     #"examples/tab_bar",
     #"examples/tabs",

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "menu"
+version = "0.1.0"
+authors = ["Kaiden42 <gitlab@tinysn.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced_aw = { path = "../..", default-features = false, features = ["menu"] }

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "0333a8daff6db989adc6035a4c09df171a86f6fe" }
 iced_aw = { path = "../..", default-features = false, features = ["menu"] }

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["menu"] }

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -1,0 +1,1085 @@
+use iced::{Column, Container, Element, Length, Sandbox, Settings, Text};
+use iced_aw::{menu, Menu};
+use menu::{Entry, Section};
+
+fn main() -> iced::Result {
+    MenuExample::run(Settings::default())
+}
+
+#[derive(Clone, Debug)]
+enum Message {
+    None,
+    Menu(MenuMessage),
+}
+
+struct MenuExample {
+    menu: menu::State,
+    last_message: Message,
+}
+
+impl Sandbox for MenuExample {
+    type Message = Message;
+
+    fn new() -> Self {
+        MenuExample {
+            menu: menu::State::new(),
+            last_message: Message::None,
+        }
+    }
+
+    fn title(&self) -> String {
+        String::from("Menu example")
+    }
+
+    fn update(&mut self, message: Self::Message) {
+        self.last_message = message;
+    }
+
+    fn view(&mut self) -> iced::Element<'_, Self::Message> {
+        let menu: Element<'_, MenuMessage> = Menu::new(&mut self.menu)
+            .push(
+                Section::new(
+                    Text::new("File"),
+                    vec![
+                        Entry::Item(Text::new("New File").into(), FileMessage::NewFile),
+                        Entry::Item(Text::new("New Window").into(), FileMessage::NewWindow),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Open File...").into(), FileMessage::OpenFile),
+                        Entry::Item(Text::new("Open Folder...").into(), FileMessage::OpenFolder),
+                        Entry::Item(
+                            Text::new("Open Workspace...").into(),
+                            FileMessage::OpenWorkspace,
+                        ),
+                        Entry::Group(
+                            Text::new("Open Recent...").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Reopen Closed Editor").into(),
+                                    OpenRecentMessage::ReopenClosedEditor,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(Text::new("Foo").into(), OpenRecentMessage::Foo),
+                                Entry::Item(Text::new("Bar").into(), OpenRecentMessage::Bar),
+                                Entry::Item(Text::new("Baz").into(), OpenRecentMessage::Baz),
+                                Entry::Separator,
+                                Entry::Item(Text::new("Foo").into(), OpenRecentMessage::Foo),
+                                Entry::Item(Text::new("Bar").into(), OpenRecentMessage::Bar),
+                                Entry::Item(Text::new("Baz").into(), OpenRecentMessage::Baz),
+                                Entry::Separator,
+                                Entry::Group(
+                                    Text::new("More...").into(),
+                                    vec![
+                                        Entry::Item(Text::new("Foo").into(), MoreMessage::Foo),
+                                        Entry::Item(Text::new("Bar").into(), MoreMessage::Bar),
+                                        Entry::Item(Text::new("Baz").into(), MoreMessage::Baz),
+                                    ],
+                                )
+                                .map(OpenRecentMessage::More),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Clear Recently Opened").into(),
+                                    OpenRecentMessage::ClearRecentlyOpened,
+                                ),
+                            ],
+                        )
+                        .map(FileMessage::OpenRecent),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Add folder to Workspace...").into(),
+                            FileMessage::AddFolderToWorkspace,
+                        ),
+                        Entry::Item(
+                            Text::new("Save Workspace As...").into(),
+                            FileMessage::SaveWorkspaceAs,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Save").into(), FileMessage::Save),
+                        Entry::Item(Text::new("Save As...").into(), FileMessage::SaveAs),
+                        Entry::Item(Text::new("Save All").into(), FileMessage::SaveAll),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Auto Save").into(), FileMessage::AutoSave),
+                        Entry::Group(
+                            Text::new("Preferences").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Settings").into(),
+                                    PreferencesMessage::Settings,
+                                ),
+                                Entry::Item(
+                                    Text::new("Online Services Settings").into(),
+                                    PreferencesMessage::OnlineServiceSettings,
+                                ),
+                                Entry::Item(
+                                    Text::new("Extensions").into(),
+                                    PreferencesMessage::Extensions,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Keyboard Shortcuts [Ctrl+K Ctrl+S]").into(),
+                                    PreferencesMessage::KeyboardShortcuts,
+                                ),
+                                Entry::Item(
+                                    Text::new("Keymaps [Ctrl+K Ctrl+M]").into(),
+                                    PreferencesMessage::Keymaps,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("User Snippets").into(),
+                                    PreferencesMessage::UserSnippets,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Color Theme [Ctrl+K Ctrl+T]").into(),
+                                    PreferencesMessage::ColorTheme,
+                                ),
+                                Entry::Item(
+                                    Text::new("File Icon Theme").into(),
+                                    PreferencesMessage::FileIconTheme,
+                                ),
+                                Entry::Item(
+                                    Text::new("Product Icon Theme").into(),
+                                    PreferencesMessage::ProductIconTheme,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Turn on Settings Sync...").into(),
+                                    PreferencesMessage::TurnOnSettingsSync,
+                                ),
+                            ],
+                        )
+                        .map(FileMessage::Preferences),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Revert File").into(), FileMessage::RevertFile),
+                        Entry::Item(Text::new("Close Editor").into(), FileMessage::CloseEditor),
+                        Entry::Item(Text::new("Close Folder").into(), FileMessage::CloseFolder),
+                        Entry::Item(Text::new("Close Window").into(), FileMessage::CloseWindow),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Exit").into(), FileMessage::Exit),
+                    ],
+                )
+                .map(MenuMessage::File),
+            )
+            .push(
+                Section::new(
+                    Text::new("Edit"),
+                    vec![
+                        Entry::Item(Text::new("Undo").into(), EditMessage::Undo),
+                        Entry::Item(Text::new("Redo").into(), EditMessage::Redo),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Cut").into(), EditMessage::Cut),
+                        Entry::Item(Text::new("Copy").into(), EditMessage::Copy),
+                        Entry::Item(Text::new("Paste").into(), EditMessage::Paste),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Find").into(), EditMessage::Find),
+                        Entry::Item(Text::new("Replace").into(), EditMessage::Replace),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Find in Files").into(), EditMessage::FindInFiles),
+                        Entry::Item(
+                            Text::new("Replace in Files").into(),
+                            EditMessage::ReplaceInFiles,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Toggle Line Comment").into(),
+                            EditMessage::ToggleLineComment,
+                        ),
+                        Entry::Item(
+                            Text::new("Toggle Block Comment").into(),
+                            EditMessage::ToggleBlockComment,
+                        ),
+                        Entry::Item(
+                            Text::new("Emmet: Expand Abbreviation").into(),
+                            EditMessage::EmmetExpandAbbreviation,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::Edit),
+            )
+            .push(
+                Section::new(
+                    Text::new("Selection"),
+                    vec![
+                        Entry::Item(Text::new("Select All").into(), SelectionMessage::SelectAll),
+                        Entry::Item(
+                            Text::new("Expand Selection").into(),
+                            SelectionMessage::ExpandSelection,
+                        ),
+                        Entry::Item(
+                            Text::new("Shrink Selection").into(),
+                            SelectionMessage::ShrinkSelection,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Copy Line Up").into(),
+                            SelectionMessage::CopyLineUp,
+                        ),
+                        Entry::Item(
+                            Text::new("Copy Line Down").into(),
+                            SelectionMessage::CopyLineDown,
+                        ),
+                        Entry::Item(
+                            Text::new("Move Line Up").into(),
+                            SelectionMessage::MoveLineUp,
+                        ),
+                        Entry::Item(
+                            Text::new("Move Line Down").into(),
+                            SelectionMessage::MoveLineDown,
+                        ),
+                        Entry::Item(
+                            Text::new("Duplicate Selection").into(),
+                            SelectionMessage::DuplicateSelection,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Add Cursor Above").into(),
+                            SelectionMessage::AddCursorAbove,
+                        ),
+                        Entry::Item(
+                            Text::new("Add Cursor Below").into(),
+                            SelectionMessage::AddCursorBelow,
+                        ),
+                        Entry::Item(
+                            Text::new("Add Cursors to Line Ends").into(),
+                            SelectionMessage::AddCursorsToLineEnds,
+                        ),
+                        Entry::Item(
+                            Text::new("Add Next Occurrence").into(),
+                            SelectionMessage::AddNextOccurrence,
+                        ),
+                        Entry::Item(
+                            Text::new("Add Previous Occurrence").into(),
+                            SelectionMessage::AddPreviousOccurrence,
+                        ),
+                        Entry::Item(
+                            Text::new("Select All Occurrences").into(),
+                            SelectionMessage::SelectAllOccurrences,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Switch to Ctrl+Click for Multi-Cursor").into(),
+                            SelectionMessage::SwitchToCtrlClickForMultiCursor,
+                        ),
+                        Entry::Item(
+                            Text::new("Column Selection Mode").into(),
+                            SelectionMessage::ColumnSelectionMode,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::Selection),
+            )
+            .push(
+                Section::new(
+                    Text::new("View"),
+                    vec![
+                        Entry::Item(
+                            Text::new("Command Palette...").into(),
+                            ViewMessage::CommandPalette,
+                        ),
+                        Entry::Item(Text::new("Open View...").into(), ViewMessage::OpenView),
+                        Entry::Separator,
+                        Entry::Group(
+                            Text::new("Appearance").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Full Screen").into(),
+                                    AppearanceMessage::FullScreen,
+                                ),
+                                Entry::Item(
+                                    Text::new("Zen Mode [Ctrl+K Z]").into(),
+                                    AppearanceMessage::ZenMode,
+                                ),
+                                Entry::Item(
+                                    Text::new("Centered Layout").into(),
+                                    AppearanceMessage::CenteredLayout,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Show Menu Bar").into(),
+                                    AppearanceMessage::ShowMenuBar,
+                                ),
+                                Entry::Item(
+                                    Text::new("Show Side Bar").into(),
+                                    AppearanceMessage::ShowSideBar,
+                                ),
+                                Entry::Item(
+                                    Text::new("Show Status Bar").into(),
+                                    AppearanceMessage::ShowStatusBar,
+                                ),
+                                Entry::Item(
+                                    Text::new("Show Activity Bar").into(),
+                                    AppearanceMessage::ShowActivityBar,
+                                ),
+                                Entry::Item(
+                                    Text::new("Show Editor Bar").into(),
+                                    AppearanceMessage::ShowEditorBar,
+                                ),
+                                Entry::Item(
+                                    Text::new("Show Panel Bar").into(),
+                                    AppearanceMessage::ShowPanelBar,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Move Side Bar Right").into(),
+                                    AppearanceMessage::MoveSideBarRight,
+                                ),
+                                Entry::Item(
+                                    Text::new("Move Panel Left").into(),
+                                    AppearanceMessage::MovePanelLeft,
+                                ),
+                                Entry::Item(
+                                    Text::new("Move Panel Right").into(),
+                                    AppearanceMessage::MovePanelRight,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(Text::new("Zoom In").into(), AppearanceMessage::ZoomIn),
+                                Entry::Item(
+                                    Text::new("Zoom Out").into(),
+                                    AppearanceMessage::ZoomOut,
+                                ),
+                                Entry::Item(
+                                    Text::new("Reset Zoom [Ctrl+NumPad0").into(),
+                                    AppearanceMessage::ResetZoom,
+                                ),
+                            ],
+                        )
+                        .map(ViewMessage::Appearance),
+                        Entry::Group(
+                            Text::new("Editor Layout").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Split Up").into(),
+                                    EditorLayoutMessage::SplitUp,
+                                ),
+                                Entry::Item(
+                                    Text::new("Split Down").into(),
+                                    EditorLayoutMessage::SplitDown,
+                                ),
+                                Entry::Item(
+                                    Text::new("Split Left").into(),
+                                    EditorLayoutMessage::SplitLeft,
+                                ),
+                                Entry::Item(
+                                    Text::new("Split Right").into(),
+                                    EditorLayoutMessage::SplitRight,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Single").into(),
+                                    EditorLayoutMessage::Single,
+                                ),
+                                Entry::Item(
+                                    Text::new("Two Columns").into(),
+                                    EditorLayoutMessage::TwoColumns,
+                                ),
+                                Entry::Item(
+                                    Text::new("Three Columns").into(),
+                                    EditorLayoutMessage::ThreeColumns,
+                                ),
+                                Entry::Item(
+                                    Text::new("Two Rows").into(),
+                                    EditorLayoutMessage::TwoRows,
+                                ),
+                                Entry::Item(
+                                    Text::new("Three Rows").into(),
+                                    EditorLayoutMessage::ThreeRows,
+                                ),
+                                Entry::Item(
+                                    Text::new("Grid (2x2)").into(),
+                                    EditorLayoutMessage::Grid,
+                                ),
+                                Entry::Item(
+                                    Text::new("Two Rows Right").into(),
+                                    EditorLayoutMessage::TwoRowsRight,
+                                ),
+                                Entry::Item(
+                                    Text::new("Two Columns Bottom").into(),
+                                    EditorLayoutMessage::TwoColumnsBottom,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Flip Layout").into(),
+                                    EditorLayoutMessage::FlipLayout,
+                                ),
+                            ],
+                        )
+                        .map(ViewMessage::EditorLayout),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Explorer").into(), ViewMessage::Explorer),
+                        Entry::Item(Text::new("Search").into(), ViewMessage::Search),
+                        Entry::Item(Text::new("SCM [Ctrl+Shift+G G]").into(), ViewMessage::Scm),
+                        Entry::Item(Text::new("Run").into(), ViewMessage::Run),
+                        Entry::Item(Text::new("Extensions").into(), ViewMessage::Extensions),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Output [Ctrl+K Ctrl+H]").into(),
+                            ViewMessage::Output,
+                        ),
+                        Entry::Item(Text::new("Debug Console").into(), ViewMessage::DebugConsole),
+                        Entry::Item(Text::new("Terminal").into(), ViewMessage::Terminal),
+                        Entry::Item(Text::new("Problems").into(), ViewMessage::Problems),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Toggle Word Wrap").into(),
+                            ViewMessage::ToggleWordWrap,
+                        ),
+                        Entry::Item(Text::new("Show Minimap").into(), ViewMessage::ShowMinimap),
+                        Entry::Item(
+                            Text::new("Show Breadcrumbs").into(),
+                            ViewMessage::ShowBreadcrumbs,
+                        ),
+                        Entry::Item(
+                            Text::new("Render Whitespace").into(),
+                            ViewMessage::RenderWhitespace,
+                        ),
+                        Entry::Item(
+                            Text::new("Render Control Characters").into(),
+                            ViewMessage::RenderControlCharacters,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::View),
+            )
+            .push(
+                Section::new(
+                    Text::new("Go"),
+                    vec![
+                        Entry::Item(Text::new("Back").into(), GoMessage::Back),
+                        Entry::Item(Text::new("Forward").into(), GoMessage::Forward),
+                        Entry::Item(
+                            Text::new("Last Edit Location [Ctrl+K Ctrl+Q]").into(),
+                            GoMessage::LastEditLocation,
+                        ),
+                        Entry::Separator,
+                        Entry::Group(
+                            Text::new("Switch Editor").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Next Editor").into(),
+                                    SwitchEditorMessage::NextEditor,
+                                ),
+                                Entry::Item(
+                                    Text::new("Previous Editor").into(),
+                                    SwitchEditorMessage::PreviousEditor,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Next Used Editor").into(),
+                                    SwitchEditorMessage::NextUsedEditor,
+                                ),
+                                Entry::Item(
+                                    Text::new("Previous Used Editor").into(),
+                                    SwitchEditorMessage::PreviousUsedEditor,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Next Editor in Group [Ctrl+K Ctrl+PageDown]").into(),
+                                    SwitchEditorMessage::NextEditorInGroup,
+                                ),
+                                Entry::Item(
+                                    Text::new("Previous Editor in Group [Ctrl+K Ctrl+PageUp]")
+                                        .into(),
+                                    SwitchEditorMessage::PreviousEditorInGroup,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Next Used Editor in Group").into(),
+                                    SwitchEditorMessage::NextUsedEditorInGroup,
+                                ),
+                                Entry::Item(
+                                    Text::new("Previous Used Editor in Group").into(),
+                                    SwitchEditorMessage::PreviousUsedEditorInGroup,
+                                ),
+                            ],
+                        )
+                        .map(GoMessage::SwitchEditor),
+                        Entry::Group(
+                            Text::new("Switch Group").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Group 1").into(),
+                                    SwitchGroupMessage::Group1,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group 2").into(),
+                                    SwitchGroupMessage::Group2,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group 3").into(),
+                                    SwitchGroupMessage::Group3,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group 4").into(),
+                                    SwitchGroupMessage::Group4,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group 5").into(),
+                                    SwitchGroupMessage::Group5,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Next Group").into(),
+                                    SwitchGroupMessage::NextGroup,
+                                ),
+                                Entry::Item(
+                                    Text::new("Previous Group").into(),
+                                    SwitchGroupMessage::PreviousGroup,
+                                ),
+                                Entry::Separator,
+                                Entry::Item(
+                                    Text::new("Group Left [Ctrl+K Ctrl+LeftArrow]").into(),
+                                    SwitchGroupMessage::GroupLeft,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group Right [Ctrl+K Ctrl+RightArrow]").into(),
+                                    SwitchGroupMessage::GroupRight,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group Above [Ctrl+K Ctrl+UpArrow]").into(),
+                                    SwitchGroupMessage::GroupAbove,
+                                ),
+                                Entry::Item(
+                                    Text::new("Group Below [Ctrl+K Ctrl+DownArrow]").into(),
+                                    SwitchGroupMessage::GroupBelow,
+                                ),
+                            ],
+                        )
+                        .map(GoMessage::SwitchGroup),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Go to File...").into(), GoMessage::GoToFile),
+                        Entry::Item(
+                            Text::new("Go to Symbol in Workspace...").into(),
+                            GoMessage::GoToSymbolInWorkspace,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Go to Symbol in Editor...").into(),
+                            GoMessage::GoToSymbolInEditor,
+                        ),
+                        Entry::Item(
+                            Text::new("Go to Definition").into(),
+                            GoMessage::GoToDefinition,
+                        ),
+                        Entry::Item(
+                            Text::new("Go to Declaration").into(),
+                            GoMessage::GoToDeclaration,
+                        ),
+                        Entry::Item(
+                            Text::new("Go to Type Definition").into(),
+                            GoMessage::GoToTypeDefinition,
+                        ),
+                        Entry::Item(
+                            Text::new("Go to Implementations").into(),
+                            GoMessage::GoToImplementations,
+                        ),
+                        Entry::Item(
+                            Text::new("Go to References").into(),
+                            GoMessage::GoToReferences,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Go to Line/Column...").into(),
+                            GoMessage::GoToLineColumn,
+                        ),
+                        Entry::Item(Text::new("Go to Bracket").into(), GoMessage::GoToBracket),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Next Problem").into(), GoMessage::NextProblem),
+                        Entry::Item(
+                            Text::new("Previous Problem").into(),
+                            GoMessage::PreviousProblem,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Next Change").into(), GoMessage::NextChange),
+                        Entry::Item(
+                            Text::new("Previous Change").into(),
+                            GoMessage::PreviousChange,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::Go),
+            )
+            .push(
+                Section::new(
+                    Text::new("Run"),
+                    vec![
+                        Entry::Item(
+                            Text::new("Start Debugging").into(),
+                            RunMessage::StartDebugging,
+                        ),
+                        Entry::Item(
+                            Text::new("Run Without Debugging").into(),
+                            RunMessage::RunWithoutDebugging,
+                        ),
+                        Entry::Item(
+                            Text::new("Stop Debugging").into(),
+                            RunMessage::StopDebugging,
+                        ),
+                        Entry::Item(
+                            Text::new("Restart Debugging").into(),
+                            RunMessage::RestartDebugging,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Open Configurations").into(),
+                            RunMessage::OpenConfigurations,
+                        ),
+                        Entry::Item(
+                            Text::new("Add Configuration...").into(),
+                            RunMessage::AddConfiguration,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Step Over").into(), RunMessage::StepOver),
+                        Entry::Item(Text::new("Step Into").into(), RunMessage::StepInto),
+                        Entry::Item(Text::new("Step Out").into(), RunMessage::StepOut),
+                        Entry::Item(Text::new("Continue").into(), RunMessage::Continue),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Toggle Breakpoint").into(),
+                            RunMessage::ToggleBreakpoint,
+                        ),
+                        Entry::Group(
+                            Text::new("New Breakpoint").into(),
+                            vec![
+                                Entry::Item(
+                                    Text::new("Conditional Breakpoint...").into(),
+                                    NewBreakpointMessage::ConditionalBreakpoint,
+                                ),
+                                Entry::Item(
+                                    Text::new("Inline Breakpoint").into(),
+                                    NewBreakpointMessage::InlineBreakpoint,
+                                ),
+                                Entry::Item(
+                                    Text::new("Function Breakpoint...").into(),
+                                    NewBreakpointMessage::FunctionBreakpoint,
+                                ),
+                                Entry::Item(
+                                    Text::new("Logpoint...").into(),
+                                    NewBreakpointMessage::Logpoint,
+                                ),
+                            ],
+                        )
+                        .map(RunMessage::NewBreakpoint),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Enable All Breakpoints").into(),
+                            RunMessage::EnableAllBreakpoints,
+                        ),
+                        Entry::Item(
+                            Text::new("Disable All Breakpoints").into(),
+                            RunMessage::DisableAllBreakpoints,
+                        ),
+                        Entry::Item(
+                            Text::new("Remove All Breakpoints").into(),
+                            RunMessage::RemoveAllBreakpoints,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Install Additional Debuggers...").into(),
+                            RunMessage::InstallAdditionalDebuggers,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::Run),
+            )
+            .push(
+                Section::new(
+                    Text::new("Terminal"),
+                    vec![
+                        Entry::Item(
+                            Text::new("New Terminal").into(),
+                            TerminalMessage::NewTerminal,
+                        ),
+                        Entry::Item(
+                            Text::new("Split Terminal").into(),
+                            TerminalMessage::SplitTerminal,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(Text::new("Run Task...").into(), TerminalMessage::RunTask),
+                        Entry::Item(
+                            Text::new("Run Build Task...").into(),
+                            TerminalMessage::RunBuildTask,
+                        ),
+                        Entry::Item(
+                            Text::new("Run Active File").into(),
+                            TerminalMessage::RunActiveFile,
+                        ),
+                        Entry::Item(
+                            Text::new("Run Selected Text").into(),
+                            TerminalMessage::RunSelectedText,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Show Running Tasks...").into(),
+                            TerminalMessage::ShowRunningTasks,
+                        ),
+                        Entry::Item(
+                            Text::new("Restart Running Tasks...").into(),
+                            TerminalMessage::RestartRunningTasks,
+                        ),
+                        Entry::Item(
+                            Text::new("Terminate Tasks...").into(),
+                            TerminalMessage::TerminateTasks,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Configure Tasks...").into(),
+                            TerminalMessage::ConfigureTasks,
+                        ),
+                        Entry::Item(
+                            Text::new("Configure Default Build Task...").into(),
+                            TerminalMessage::ConfigureDefaultBuildTasks,
+                        ),
+                    ],
+                )
+                .map(MenuMessage::Terminal),
+            )
+            .push(
+                Section::new(
+                    Text::new("Help"),
+                    vec![
+                        Entry::Item(Text::new("Welcome").into(), HelpMessage::Welcome),
+                        Entry::Item(
+                            Text::new("Interactive Playground").into(),
+                            HelpMessage::InteractivePlayground,
+                        ),
+                        Entry::Item(
+                            Text::new("Documentation").into(),
+                            HelpMessage::Documentation,
+                        ),
+                        Entry::Item(Text::new("Release Notes").into(), HelpMessage::ReleaseNotes),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Keyboard Shortcuts Reference [Ctrl+K Ctrl+R]").into(),
+                            HelpMessage::KeyboardShortCutsReference,
+                        ),
+                        Entry::Item(
+                            Text::new("Introductory Videos").into(),
+                            HelpMessage::IntroductoryVideos,
+                        ),
+                        Entry::Item(
+                            Text::new("Tips and Tricks").into(),
+                            HelpMessage::TipsAndTricks,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Join Us on Twitter").into(),
+                            HelpMessage::JoinUsOnTwitter,
+                        ),
+                        Entry::Item(
+                            Text::new("Search Feature Requests").into(),
+                            HelpMessage::SearchFeatureRequests,
+                        ),
+                        Entry::Item(Text::new("Report Issue").into(), HelpMessage::ReportIssue),
+                        Entry::Separator,
+                        Entry::Item(Text::new("View License").into(), HelpMessage::ViewLicense),
+                        Entry::Item(
+                            Text::new("Privacy Statement").into(),
+                            HelpMessage::PrivacyStatement,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Toggle Developer Tools").into(),
+                            HelpMessage::ToggleDeveloperTools,
+                        ),
+                        Entry::Item(
+                            Text::new("Open Process Explorer").into(),
+                            HelpMessage::OpenProcessExplorer,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(
+                            Text::new("Download Available Update").into(),
+                            HelpMessage::DownloadAvailableUpdate,
+                        ),
+                        Entry::Separator,
+                        Entry::Item(Text::new("About").into(), HelpMessage::About),
+                    ],
+                )
+                .map(MenuMessage::Help),
+            )
+            .into();
+
+        let menu = menu.map(Message::Menu);
+
+        Column::new()
+            .push(menu)
+            .push(
+                Container::new(Text::new(format!("Last Message: {:?}", self.last_message)))
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .center_x()
+                    .center_y(),
+            )
+            .into()
+    }
+}
+
+#[derive(Clone, Debug)]
+enum MenuMessage {
+    File(FileMessage),
+    Edit(EditMessage),
+    Selection(SelectionMessage),
+    View(ViewMessage),
+    Go(GoMessage),
+    Run(RunMessage),
+    Terminal(TerminalMessage),
+    Help(HelpMessage),
+}
+
+#[derive(Clone, Debug)]
+enum FileMessage {
+    NewFile,
+    NewWindow,
+    OpenFile,
+    OpenFolder,
+    OpenWorkspace,
+    OpenRecent(OpenRecentMessage),
+    AddFolderToWorkspace,
+    SaveWorkspaceAs,
+    Save,
+    SaveAs,
+    SaveAll,
+    AutoSave,
+    Preferences(PreferencesMessage),
+    RevertFile,
+    CloseEditor,
+    CloseFolder,
+    CloseWindow,
+    Exit,
+}
+
+#[derive(Clone, Debug)]
+enum OpenRecentMessage {
+    ReopenClosedEditor,
+    Foo,
+    Bar,
+    Baz,
+    More(MoreMessage),
+    ClearRecentlyOpened,
+}
+
+#[derive(Clone, Debug)]
+enum MoreMessage {
+    Foo,
+    Bar,
+    Baz,
+}
+
+#[derive(Clone, Debug)]
+enum PreferencesMessage {
+    Settings,
+    OnlineServiceSettings,
+    Extensions,
+    KeyboardShortcuts,
+    Keymaps,
+    UserSnippets,
+    ColorTheme,
+    FileIconTheme,
+    ProductIconTheme,
+    TurnOnSettingsSync,
+}
+
+#[derive(Clone, Debug)]
+enum EditMessage {
+    Undo,
+    Redo,
+    Cut,
+    Copy,
+    Paste,
+    Find,
+    Replace,
+    FindInFiles,
+    ReplaceInFiles,
+    ToggleLineComment,
+    ToggleBlockComment,
+    EmmetExpandAbbreviation,
+}
+
+#[derive(Clone, Debug)]
+enum SelectionMessage {
+    SelectAll,
+    ExpandSelection,
+    ShrinkSelection,
+    CopyLineUp,
+    CopyLineDown,
+    MoveLineUp,
+    MoveLineDown,
+    DuplicateSelection,
+    AddCursorAbove,
+    AddCursorBelow,
+    AddCursorsToLineEnds,
+    AddNextOccurrence,
+    AddPreviousOccurrence,
+    SelectAllOccurrences,
+    SwitchToCtrlClickForMultiCursor,
+    ColumnSelectionMode,
+}
+
+#[derive(Clone, Debug)]
+enum ViewMessage {
+    CommandPalette,
+    OpenView,
+    Appearance(AppearanceMessage),
+    EditorLayout(EditorLayoutMessage),
+    Explorer,
+    Search,
+    Scm,
+    Run,
+    Extensions,
+    Output,
+    DebugConsole,
+    Terminal,
+    Problems,
+    ToggleWordWrap,
+    ShowMinimap,
+    ShowBreadcrumbs,
+    RenderWhitespace,
+    RenderControlCharacters,
+}
+
+#[derive(Clone, Debug)]
+enum AppearanceMessage {
+    FullScreen,
+    ZenMode,
+    CenteredLayout,
+    ShowMenuBar,
+    ShowSideBar,
+    ShowStatusBar,
+    ShowActivityBar,
+    ShowEditorBar,
+    ShowPanelBar,
+    MoveSideBarRight,
+    MovePanelLeft,
+    MovePanelRight,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+}
+
+#[derive(Clone, Debug)]
+enum EditorLayoutMessage {
+    SplitUp,
+    SplitDown,
+    SplitLeft,
+    SplitRight,
+    Single,
+    TwoColumns,
+    ThreeColumns,
+    TwoRows,
+    ThreeRows,
+    Grid,
+    TwoRowsRight,
+    TwoColumnsBottom,
+    FlipLayout,
+}
+
+#[derive(Clone, Debug)]
+enum GoMessage {
+    Back,
+    Forward,
+    LastEditLocation,
+    SwitchEditor(SwitchEditorMessage),
+    SwitchGroup(SwitchGroupMessage),
+    GoToFile,
+    GoToSymbolInWorkspace,
+    GoToSymbolInEditor,
+    GoToDefinition,
+    GoToDeclaration,
+    GoToTypeDefinition,
+    GoToImplementations,
+    GoToReferences,
+    GoToLineColumn,
+    GoToBracket,
+    NextProblem,
+    PreviousProblem,
+    NextChange,
+    PreviousChange,
+}
+
+#[derive(Clone, Debug)]
+enum SwitchEditorMessage {
+    NextEditor,
+    PreviousEditor,
+    NextUsedEditor,
+    PreviousUsedEditor,
+    NextEditorInGroup,
+    PreviousEditorInGroup,
+    NextUsedEditorInGroup,
+    PreviousUsedEditorInGroup,
+}
+
+#[derive(Clone, Debug)]
+enum SwitchGroupMessage {
+    Group1,
+    Group2,
+    Group3,
+    Group4,
+    Group5,
+    NextGroup,
+    PreviousGroup,
+    GroupLeft,
+    GroupRight,
+    GroupAbove,
+    GroupBelow,
+}
+
+#[derive(Clone, Debug)]
+enum RunMessage {
+    StartDebugging,
+    RunWithoutDebugging,
+    StopDebugging,
+    RestartDebugging,
+    OpenConfigurations,
+    AddConfiguration,
+    StepOver,
+    StepInto,
+    StepOut,
+    Continue,
+    ToggleBreakpoint,
+    NewBreakpoint(NewBreakpointMessage),
+    EnableAllBreakpoints,
+    DisableAllBreakpoints,
+    RemoveAllBreakpoints,
+    InstallAdditionalDebuggers,
+}
+
+#[derive(Clone, Debug)]
+enum NewBreakpointMessage {
+    ConditionalBreakpoint,
+    InlineBreakpoint,
+    FunctionBreakpoint,
+    Logpoint,
+}
+
+#[derive(Clone, Debug)]
+enum TerminalMessage {
+    NewTerminal,
+    SplitTerminal,
+    RunTask,
+    RunBuildTask,
+    RunActiveFile,
+    RunSelectedText,
+    ShowRunningTasks,
+    RestartRunningTasks,
+    TerminateTasks,
+    ConfigureTasks,
+    ConfigureDefaultBuildTasks,
+}
+
+#[derive(Clone, Debug)]
+enum HelpMessage {
+    Welcome,
+    InteractivePlayground,
+    Documentation,
+    ReleaseNotes,
+    KeyboardShortCutsReference,
+    IntroductoryVideos,
+    TipsAndTricks,
+    JoinUsOnTwitter,
+    SearchFeatureRequests,
+    ReportIssue,
+    ViewLicense,
+    PrivacyStatement,
+    ToggleDeveloperTools,
+    OpenProcessExplorer,
+    DownloadAvailableUpdate,
+    About,
+}

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -19,43 +19,157 @@ struct MenuExample {
 }
 #[derive(Default)]
 struct MenuConfig {
-    enable_reopen_closed_editor: bool,
+    enable: EnableEntries,
+    toggle: ToggleEntries,
+}
 
-    enable_save_all: bool,
+#[derive(Default)]
+struct EnableEntries {
+    reopen_closed_editor: bool,
 
-    enable_forward: bool,
+    save_all: bool,
 
-    enable_group_3: bool,
-    enable_group_4: bool,
-    enable_group_5: bool,
+    forward: bool,
 
-    enable_next_group: bool,
-    enable_previous_group: bool,
+    group_3: bool,
+    group_4: bool,
+    group_5: bool,
 
-    enable_group_left: bool,
-    enable_group_right: bool,
-    enable_group_above: bool,
-    enable_group_below: bool,
+    next_group: bool,
+    previous_group: bool,
 
-    enable_go_to_definition: bool,
-    enable_go_to_declaration: bool,
-    enable_go_to_type_definition: bool,
-    enable_go_to_implementations: bool,
-    enable_go_to_references: bool,
+    group_left: bool,
+    group_right: bool,
+    group_above: bool,
+    group_below: bool,
 
-    enable_stop_debugging: bool,
-    enable_restart_debugging: bool,
+    go_to_definition: bool,
+    go_to_declaration: bool,
+    go_to_type_definition: bool,
+    go_to_implementations: bool,
+    go_to_references: bool,
 
-    enable_open_configuration: bool,
+    stop_debugging: bool,
+    restart_debugging: bool,
 
-    enable_step_over: bool,
-    enable_step_into: bool,
-    enable_step_out: bool,
-    enable_continue: bool,
+    open_configuration: bool,
 
-    enable_show_running_tasks: bool,
-    enable_restart_running_tasks: bool,
-    enable_terminate_tasks: bool,
+    step_over: bool,
+    step_into: bool,
+    step_out: bool,
+    r#continue: bool,
+
+    show_running_tasks: bool,
+    restart_running_tasks: bool,
+    terminate_tasks: bool,
+}
+
+struct ToggleEntries {
+    auto_save: bool,
+
+    column_selection_mode: bool,
+
+    show_minimap: bool,
+    show_breadcrumbs: bool,
+    render_whitespace: bool,
+    render_control_characters: bool,
+
+    full_screen: bool,
+    zen_mode: bool,
+    centered_layout: bool,
+    show_menu_bar: bool,
+    show_side_bar: bool,
+    show_status_bar: bool,
+    show_activity_bar: bool,
+    show_editor_bar: bool,
+    show_panel_bar: bool,
+}
+
+impl Default for ToggleEntries {
+    fn default() -> Self {
+        Self {
+            auto_save: true,
+            column_selection_mode: false,
+            show_minimap: true,
+            show_breadcrumbs: false,
+            render_whitespace: false,
+            render_control_characters: true,
+            full_screen: false,
+            zen_mode: true,
+            centered_layout: false,
+            show_menu_bar: true,
+            show_side_bar: true,
+            show_status_bar: true,
+            show_activity_bar: false,
+            show_editor_bar: false,
+            show_panel_bar: false,
+        }
+    }
+}
+
+impl ToggleEntries {
+    pub fn update(&mut self, message: MenuMessage) {
+        match message {
+            MenuMessage::File(file) => match file {
+                FileMessage::AutoSave(b) => {
+                    self.auto_save = b;
+                }
+                _ => {}
+            },
+            MenuMessage::Selection(selection) => match selection {
+                SelectionMessage::ColumnSelectionMode(b) => {
+                    self.column_selection_mode = b;
+                }
+                _ => {}
+            },
+            MenuMessage::View(view) => match view {
+                ViewMessage::Appearance(appearance) => match appearance {
+                    AppearanceMessage::FullScreen(b) => {
+                        self.full_screen = b;
+                    }
+                    AppearanceMessage::ZenMode(b) => {
+                        self.zen_mode = b;
+                    }
+                    AppearanceMessage::CenteredLayout(b) => {
+                        self.centered_layout = b;
+                    }
+                    AppearanceMessage::ShowMenuBar(b) => {
+                        self.show_menu_bar = b;
+                    }
+                    AppearanceMessage::ShowSideBar(b) => {
+                        self.show_side_bar = b;
+                    }
+                    AppearanceMessage::ShowStatusBar(b) => {
+                        self.show_status_bar = b;
+                    }
+                    AppearanceMessage::ShowActivityBar(b) => {
+                        self.show_activity_bar = b;
+                    }
+                    AppearanceMessage::ShowEditorBar(b) => {
+                        self.show_editor_bar = b;
+                    }
+                    AppearanceMessage::ShowPanelBar(b) => {
+                        self.show_panel_bar = b;
+                    }
+                    _ => {}
+                },
+                ViewMessage::ShowMinimap(b) => {
+                    self.show_minimap = b;
+                }
+                ViewMessage::ShowBreadcrumbs(b) => {
+                    self.show_breadcrumbs = b;
+                }
+                ViewMessage::RenderWhitespace(b) => {
+                    self.render_whitespace = b;
+                }
+                ViewMessage::RenderControlCharacters(b) => {
+                    self.render_control_characters = b;
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
 }
 
 impl Sandbox for MenuExample {
@@ -74,6 +188,9 @@ impl Sandbox for MenuExample {
     }
 
     fn update(&mut self, message: Self::Message) {
+        if let Message::Menu(message) = message.clone() {
+            self.config.toggle.update(message);
+        }
         self.last_message = message;
     }
 
@@ -103,7 +220,7 @@ impl Sandbox for MenuExample {
                             vec![
                                 Entry::Item(
                                     Text::new("Reopen Closed Editor").into(),
-                                    if self.config.enable_reopen_closed_editor {
+                                    if self.config.enable.reopen_closed_editor {
                                         Some(OpenRecentMessage::ReopenClosedEditor)
                                     } else {
                                         None
@@ -158,14 +275,18 @@ impl Sandbox for MenuExample {
                         Entry::Item(Text::new("Save As...").into(), Some(FileMessage::SaveAs)),
                         Entry::Item(
                             Text::new("Save All").into(),
-                            if self.config.enable_save_all {
+                            if self.config.enable.save_all {
                                 Some(FileMessage::SaveAll)
                             } else {
                                 None
                             },
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Auto Save").into(), Some(FileMessage::AutoSave)),
+                        Entry::Toggle(
+                            Text::new("Auto Save").into(),
+                            self.config.toggle.auto_save,
+                            Some(Box::new(FileMessage::AutoSave)),
+                        ),
                         Entry::Group(
                             Text::new("Preferences").into(),
                             vec![
@@ -345,9 +466,10 @@ impl Sandbox for MenuExample {
                             Text::new("Switch to Ctrl+Click for Multi-Cursor").into(),
                             Some(SelectionMessage::SwitchToCtrlClickForMultiCursor),
                         ),
-                        Entry::Item(
+                        Entry::Toggle(
                             Text::new("Column Selection Mode").into(),
-                            Some(SelectionMessage::ColumnSelectionMode),
+                            self.config.toggle.column_selection_mode,
+                            Some(Box::new(SelectionMessage::ColumnSelectionMode)),
                         ),
                     ],
                 )
@@ -369,42 +491,51 @@ impl Sandbox for MenuExample {
                         Entry::Group(
                             Text::new("Appearance").into(),
                             vec![
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Full Screen").into(),
-                                    Some(AppearanceMessage::FullScreen),
+                                    self.config.toggle.full_screen,
+                                    Some(Box::new(AppearanceMessage::FullScreen)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Zen Mode [Ctrl+K Z]").into(),
-                                    Some(AppearanceMessage::ZenMode),
+                                    self.config.toggle.zen_mode,
+                                    Some(Box::new(AppearanceMessage::ZenMode)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Centered Layout").into(),
-                                    Some(AppearanceMessage::CenteredLayout),
+                                    self.config.toggle.centered_layout,
+                                    Some(Box::new(AppearanceMessage::CenteredLayout)),
                                 ),
                                 Entry::Separator,
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Menu Bar").into(),
-                                    Some(AppearanceMessage::ShowMenuBar),
+                                    self.config.toggle.show_menu_bar,
+                                    Some(Box::new(AppearanceMessage::ShowMenuBar)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Side Bar").into(),
-                                    Some(AppearanceMessage::ShowSideBar),
+                                    self.config.toggle.show_side_bar,
+                                    Some(Box::new(AppearanceMessage::ShowSideBar)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Status Bar").into(),
-                                    Some(AppearanceMessage::ShowStatusBar),
+                                    self.config.toggle.show_status_bar,
+                                    Some(Box::new(AppearanceMessage::ShowStatusBar)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Activity Bar").into(),
-                                    Some(AppearanceMessage::ShowActivityBar),
+                                    self.config.toggle.show_activity_bar,
+                                    Some(Box::new(AppearanceMessage::ShowActivityBar)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Editor Bar").into(),
-                                    Some(AppearanceMessage::ShowEditorBar),
+                                    self.config.toggle.show_editor_bar,
+                                    Some(Box::new(AppearanceMessage::ShowEditorBar)),
                                 ),
-                                Entry::Item(
+                                Entry::Toggle(
                                     Text::new("Show Panel Bar").into(),
-                                    Some(AppearanceMessage::ShowPanelBar),
+                                    self.config.toggle.show_panel_bar,
+                                    Some(Box::new(AppearanceMessage::ShowPanelBar)),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
@@ -523,21 +654,25 @@ impl Sandbox for MenuExample {
                             Text::new("Toggle Word Wrap").into(),
                             Some(ViewMessage::ToggleWordWrap),
                         ),
-                        Entry::Item(
+                        Entry::Toggle(
                             Text::new("Show Minimap").into(),
-                            Some(ViewMessage::ShowMinimap),
+                            self.config.toggle.show_minimap,
+                            Some(Box::new(ViewMessage::ShowMinimap)),
                         ),
-                        Entry::Item(
+                        Entry::Toggle(
                             Text::new("Show Breadcrumbs").into(),
-                            Some(ViewMessage::ShowBreadcrumbs),
+                            self.config.toggle.show_breadcrumbs,
+                            Some(Box::new(ViewMessage::ShowBreadcrumbs)),
                         ),
-                        Entry::Item(
+                        Entry::Toggle(
                             Text::new("Render Whitespace").into(),
-                            Some(ViewMessage::RenderWhitespace),
+                            self.config.toggle.render_whitespace,
+                            Some(Box::new(ViewMessage::RenderWhitespace)),
                         ),
-                        Entry::Item(
+                        Entry::Toggle(
                             Text::new("Render Control Characters").into(),
-                            Some(ViewMessage::RenderControlCharacters),
+                            self.config.toggle.render_control_characters,
+                            Some(Box::new(ViewMessage::RenderControlCharacters)),
                         ),
                     ],
                 )
@@ -550,7 +685,7 @@ impl Sandbox for MenuExample {
                         Entry::Item(Text::new("Back").into(), Some(GoMessage::Back)),
                         Entry::Item(
                             Text::new("Forward").into(),
-                            if self.config.enable_forward {
+                            if self.config.enable.forward {
                                 Some(GoMessage::Forward)
                             } else {
                                 None
@@ -616,7 +751,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group 3").into(),
-                                    if self.config.enable_group_3 {
+                                    if self.config.enable.group_3 {
                                         Some(SwitchGroupMessage::Group3)
                                     } else {
                                         None
@@ -624,7 +759,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group 4").into(),
-                                    if self.config.enable_group_4 {
+                                    if self.config.enable.group_4 {
                                         Some(SwitchGroupMessage::Group4)
                                     } else {
                                         None
@@ -632,7 +767,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group 5").into(),
-                                    if self.config.enable_group_5 {
+                                    if self.config.enable.group_5 {
                                         Some(SwitchGroupMessage::Group5)
                                     } else {
                                         None
@@ -641,7 +776,7 @@ impl Sandbox for MenuExample {
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Next Group").into(),
-                                    if self.config.enable_next_group {
+                                    if self.config.enable.next_group {
                                         Some(SwitchGroupMessage::NextGroup)
                                     } else {
                                         None
@@ -649,7 +784,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Group").into(),
-                                    if self.config.enable_previous_group {
+                                    if self.config.enable.previous_group {
                                         Some(SwitchGroupMessage::PreviousGroup)
                                     } else {
                                         None
@@ -658,7 +793,7 @@ impl Sandbox for MenuExample {
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Group Left [Ctrl+K Ctrl+LeftArrow]").into(),
-                                    if self.config.enable_group_left {
+                                    if self.config.enable.group_left {
                                         Some(SwitchGroupMessage::GroupLeft)
                                     } else {
                                         None
@@ -666,7 +801,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group Right [Ctrl+K Ctrl+RightArrow]").into(),
-                                    if self.config.enable_group_right {
+                                    if self.config.enable.group_right {
                                         Some(SwitchGroupMessage::GroupRight)
                                     } else {
                                         None
@@ -674,7 +809,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group Above [Ctrl+K Ctrl+UpArrow]").into(),
-                                    if self.config.enable_group_above {
+                                    if self.config.enable.group_above {
                                         Some(SwitchGroupMessage::GroupAbove)
                                     } else {
                                         None
@@ -682,7 +817,7 @@ impl Sandbox for MenuExample {
                                 ),
                                 Entry::Item(
                                     Text::new("Group Below [Ctrl+K Ctrl+DownArrow]").into(),
-                                    if self.config.enable_group_below {
+                                    if self.config.enable.group_below {
                                         Some(SwitchGroupMessage::GroupBelow)
                                     } else {
                                         None
@@ -704,7 +839,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Go to Definition").into(),
-                            if self.config.enable_go_to_definition {
+                            if self.config.enable.go_to_definition {
                                 Some(GoMessage::GoToDefinition)
                             } else {
                                 None
@@ -712,7 +847,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Go to Declaration").into(),
-                            if self.config.enable_go_to_declaration {
+                            if self.config.enable.go_to_declaration {
                                 Some(GoMessage::GoToDeclaration)
                             } else {
                                 None
@@ -720,7 +855,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Go to Type Definition").into(),
-                            if self.config.enable_go_to_type_definition {
+                            if self.config.enable.go_to_type_definition {
                                 Some(GoMessage::GoToTypeDefinition)
                             } else {
                                 None
@@ -728,7 +863,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Go to Implementations").into(),
-                            if self.config.enable_go_to_implementations {
+                            if self.config.enable.go_to_implementations {
                                 Some(GoMessage::GoToImplementations)
                             } else {
                                 None
@@ -736,7 +871,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Go to References").into(),
-                            if self.config.enable_go_to_references {
+                            if self.config.enable.go_to_references {
                                 Some(GoMessage::GoToReferences)
                             } else {
                                 None
@@ -784,7 +919,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Stop Debugging").into(),
-                            if self.config.enable_stop_debugging {
+                            if self.config.enable.stop_debugging {
                                 Some(RunMessage::StopDebugging)
                             } else {
                                 None
@@ -792,7 +927,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Restart Debugging").into(),
-                            if self.config.enable_restart_debugging {
+                            if self.config.enable.restart_debugging {
                                 Some(RunMessage::RestartDebugging)
                             } else {
                                 None
@@ -801,7 +936,7 @@ impl Sandbox for MenuExample {
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Open Configurations").into(),
-                            if self.config.enable_open_configuration {
+                            if self.config.enable.open_configuration {
                                 Some(RunMessage::OpenConfigurations)
                             } else {
                                 None
@@ -814,7 +949,7 @@ impl Sandbox for MenuExample {
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Step Over").into(),
-                            if self.config.enable_step_over {
+                            if self.config.enable.step_over {
                                 Some(RunMessage::StepOver)
                             } else {
                                 None
@@ -822,7 +957,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Step Into").into(),
-                            if self.config.enable_step_into {
+                            if self.config.enable.step_into {
                                 Some(RunMessage::StepInto)
                             } else {
                                 None
@@ -830,7 +965,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Step Out").into(),
-                            if self.config.enable_step_out {
+                            if self.config.enable.step_out {
                                 Some(RunMessage::StepOut)
                             } else {
                                 None
@@ -838,7 +973,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Continue").into(),
-                            if self.config.enable_continue {
+                            if self.config.enable.r#continue {
                                 Some(RunMessage::Continue)
                             } else {
                                 None
@@ -925,7 +1060,7 @@ impl Sandbox for MenuExample {
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Show Running Tasks...").into(),
-                            if self.config.enable_show_running_tasks {
+                            if self.config.enable.show_running_tasks {
                                 Some(TerminalMessage::ShowRunningTasks)
                             } else {
                                 None
@@ -933,7 +1068,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Restart Running Tasks...").into(),
-                            if self.config.enable_restart_running_tasks {
+                            if self.config.enable.restart_running_tasks {
                                 Some(TerminalMessage::RestartRunningTasks)
                             } else {
                                 None
@@ -941,7 +1076,7 @@ impl Sandbox for MenuExample {
                         ),
                         Entry::Item(
                             Text::new("Terminate Tasks...").into(),
-                            if self.config.enable_terminate_tasks {
+                            if self.config.enable.terminate_tasks {
                                 Some(TerminalMessage::TerminateTasks)
                             } else {
                                 None
@@ -1074,7 +1209,7 @@ enum FileMessage {
     Save,
     SaveAs,
     SaveAll,
-    AutoSave,
+    AutoSave(bool),
     Preferences(PreferencesMessage),
     RevertFile,
     CloseEditor,
@@ -1147,7 +1282,7 @@ enum SelectionMessage {
     AddPreviousOccurrence,
     SelectAllOccurrences,
     SwitchToCtrlClickForMultiCursor,
-    ColumnSelectionMode,
+    ColumnSelectionMode(bool),
 }
 
 #[derive(Clone, Debug)]
@@ -1166,23 +1301,23 @@ enum ViewMessage {
     Terminal,
     Problems,
     ToggleWordWrap,
-    ShowMinimap,
-    ShowBreadcrumbs,
-    RenderWhitespace,
-    RenderControlCharacters,
+    ShowMinimap(bool),
+    ShowBreadcrumbs(bool),
+    RenderWhitespace(bool),
+    RenderControlCharacters(bool),
 }
 
 #[derive(Clone, Debug)]
 enum AppearanceMessage {
-    FullScreen,
-    ZenMode,
-    CenteredLayout,
-    ShowMenuBar,
-    ShowSideBar,
-    ShowStatusBar,
-    ShowActivityBar,
-    ShowEditorBar,
-    ShowPanelBar,
+    FullScreen(bool),
+    ZenMode(bool),
+    CenteredLayout(bool),
+    ShowMenuBar(bool),
+    ShowSideBar(bool),
+    ShowStatusBar(bool),
+    ShowActivityBar(bool),
+    ShowEditorBar(bool),
+    ShowPanelBar(bool),
     MoveSideBarRight,
     MovePanelLeft,
     MovePanelRight,

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -108,6 +108,7 @@ impl Default for ToggleEntries {
 }
 
 impl ToggleEntries {
+    #[allow(clippy::collapsible_match, clippy::single_match)]
     pub fn update(&mut self, message: MenuMessage) {
         match message {
             MenuMessage::File(file) => match file {

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -15,6 +15,47 @@ enum Message {
 struct MenuExample {
     menu: menu::State,
     last_message: Message,
+    config: MenuConfig,
+}
+#[derive(Default)]
+struct MenuConfig {
+    enable_reopen_closed_editor: bool,
+
+    enable_save_all: bool,
+
+    enable_forward: bool,
+
+    enable_group_3: bool,
+    enable_group_4: bool,
+    enable_group_5: bool,
+
+    enable_next_group: bool,
+    enable_previous_group: bool,
+
+    enable_group_left: bool,
+    enable_group_right: bool,
+    enable_group_above: bool,
+    enable_group_below: bool,
+
+    enable_go_to_definition: bool,
+    enable_go_to_declaration: bool,
+    enable_go_to_type_definition: bool,
+    enable_go_to_implementations: bool,
+    enable_go_to_references: bool,
+
+    enable_stop_debugging: bool,
+    enable_restart_debugging: bool,
+
+    enable_open_configuration: bool,
+
+    enable_step_over: bool,
+    enable_step_into: bool,
+    enable_step_out: bool,
+    enable_continue: bool,
+
+    enable_show_running_tasks: bool,
+    enable_restart_running_tasks: bool,
+    enable_terminate_tasks: bool,
 }
 
 impl Sandbox for MenuExample {
@@ -24,6 +65,7 @@ impl Sandbox for MenuExample {
         MenuExample {
             menu: menu::State::new(),
             last_message: Message::None,
+            config: MenuConfig::default(),
         }
     }
 
@@ -41,44 +83,63 @@ impl Sandbox for MenuExample {
                 Section::new(
                     Text::new("File"),
                     vec![
-                        Entry::Item(Text::new("New File").into(), FileMessage::NewFile),
-                        Entry::Item(Text::new("New Window").into(), FileMessage::NewWindow),
+                        Entry::Item(Text::new("New File").into(), Some(FileMessage::NewFile)),
+                        Entry::Item(Text::new("New Window").into(), Some(FileMessage::NewWindow)),
                         Entry::Separator,
-                        Entry::Item(Text::new("Open File...").into(), FileMessage::OpenFile),
-                        Entry::Item(Text::new("Open Folder...").into(), FileMessage::OpenFolder),
+                        Entry::Item(
+                            Text::new("Open File...").into(),
+                            Some(FileMessage::OpenFile),
+                        ),
+                        Entry::Item(
+                            Text::new("Open Folder...").into(),
+                            Some(FileMessage::OpenFolder),
+                        ),
                         Entry::Item(
                             Text::new("Open Workspace...").into(),
-                            FileMessage::OpenWorkspace,
+                            Some(FileMessage::OpenWorkspace),
                         ),
                         Entry::Group(
                             Text::new("Open Recent...").into(),
                             vec![
                                 Entry::Item(
                                     Text::new("Reopen Closed Editor").into(),
-                                    OpenRecentMessage::ReopenClosedEditor,
+                                    if self.config.enable_reopen_closed_editor {
+                                        Some(OpenRecentMessage::ReopenClosedEditor)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Separator,
-                                Entry::Item(Text::new("Foo").into(), OpenRecentMessage::Foo),
-                                Entry::Item(Text::new("Bar").into(), OpenRecentMessage::Bar),
-                                Entry::Item(Text::new("Baz").into(), OpenRecentMessage::Baz),
+                                Entry::Item(Text::new("Foo").into(), Some(OpenRecentMessage::Foo)),
+                                Entry::Item(Text::new("Bar").into(), Some(OpenRecentMessage::Bar)),
+                                Entry::Item(Text::new("Baz").into(), Some(OpenRecentMessage::Baz)),
                                 Entry::Separator,
-                                Entry::Item(Text::new("Foo").into(), OpenRecentMessage::Foo),
-                                Entry::Item(Text::new("Bar").into(), OpenRecentMessage::Bar),
-                                Entry::Item(Text::new("Baz").into(), OpenRecentMessage::Baz),
+                                Entry::Item(Text::new("Foo").into(), Some(OpenRecentMessage::Foo)),
+                                Entry::Item(Text::new("Bar").into(), Some(OpenRecentMessage::Bar)),
+                                Entry::Item(Text::new("Baz").into(), Some(OpenRecentMessage::Baz)),
                                 Entry::Separator,
                                 Entry::Group(
                                     Text::new("More...").into(),
                                     vec![
-                                        Entry::Item(Text::new("Foo").into(), MoreMessage::Foo),
-                                        Entry::Item(Text::new("Bar").into(), MoreMessage::Bar),
-                                        Entry::Item(Text::new("Baz").into(), MoreMessage::Baz),
+                                        Entry::Item(
+                                            Text::new("Foo").into(),
+                                            Some(MoreMessage::Foo),
+                                        ),
+                                        Entry::Item(
+                                            Text::new("Bar").into(),
+                                            Some(MoreMessage::Bar),
+                                        ),
+                                        Entry::Item(
+                                            Text::new("Baz").into(),
+                                            Some(MoreMessage::Baz),
+                                        ),
                                     ],
                                 )
                                 .map(OpenRecentMessage::More),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Clear Recently Opened").into(),
-                                    OpenRecentMessage::ClearRecentlyOpened,
+                                    Some(OpenRecentMessage::ClearRecentlyOpened),
                                 ),
                             ],
                         )
@@ -86,75 +147,94 @@ impl Sandbox for MenuExample {
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Add folder to Workspace...").into(),
-                            FileMessage::AddFolderToWorkspace,
+                            Some(FileMessage::AddFolderToWorkspace),
                         ),
                         Entry::Item(
                             Text::new("Save Workspace As...").into(),
-                            FileMessage::SaveWorkspaceAs,
+                            Some(FileMessage::SaveWorkspaceAs),
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Save").into(), FileMessage::Save),
-                        Entry::Item(Text::new("Save As...").into(), FileMessage::SaveAs),
-                        Entry::Item(Text::new("Save All").into(), FileMessage::SaveAll),
+                        Entry::Item(Text::new("Save").into(), Some(FileMessage::Save)),
+                        Entry::Item(Text::new("Save As...").into(), Some(FileMessage::SaveAs)),
+                        Entry::Item(
+                            Text::new("Save All").into(),
+                            if self.config.enable_save_all {
+                                Some(FileMessage::SaveAll)
+                            } else {
+                                None
+                            },
+                        ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Auto Save").into(), FileMessage::AutoSave),
+                        Entry::Item(Text::new("Auto Save").into(), Some(FileMessage::AutoSave)),
                         Entry::Group(
                             Text::new("Preferences").into(),
                             vec![
                                 Entry::Item(
                                     Text::new("Settings").into(),
-                                    PreferencesMessage::Settings,
+                                    Some(PreferencesMessage::Settings),
                                 ),
                                 Entry::Item(
                                     Text::new("Online Services Settings").into(),
-                                    PreferencesMessage::OnlineServiceSettings,
+                                    Some(PreferencesMessage::OnlineServiceSettings),
                                 ),
                                 Entry::Item(
                                     Text::new("Extensions").into(),
-                                    PreferencesMessage::Extensions,
+                                    Some(PreferencesMessage::Extensions),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Keyboard Shortcuts [Ctrl+K Ctrl+S]").into(),
-                                    PreferencesMessage::KeyboardShortcuts,
+                                    Some(PreferencesMessage::KeyboardShortcuts),
                                 ),
                                 Entry::Item(
                                     Text::new("Keymaps [Ctrl+K Ctrl+M]").into(),
-                                    PreferencesMessage::Keymaps,
+                                    Some(PreferencesMessage::Keymaps),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("User Snippets").into(),
-                                    PreferencesMessage::UserSnippets,
+                                    Some(PreferencesMessage::UserSnippets),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Color Theme [Ctrl+K Ctrl+T]").into(),
-                                    PreferencesMessage::ColorTheme,
+                                    Some(PreferencesMessage::ColorTheme),
                                 ),
                                 Entry::Item(
                                     Text::new("File Icon Theme").into(),
-                                    PreferencesMessage::FileIconTheme,
+                                    Some(PreferencesMessage::FileIconTheme),
                                 ),
                                 Entry::Item(
                                     Text::new("Product Icon Theme").into(),
-                                    PreferencesMessage::ProductIconTheme,
+                                    Some(PreferencesMessage::ProductIconTheme),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Turn on Settings Sync...").into(),
-                                    PreferencesMessage::TurnOnSettingsSync,
+                                    Some(PreferencesMessage::TurnOnSettingsSync),
                                 ),
                             ],
                         )
                         .map(FileMessage::Preferences),
                         Entry::Separator,
-                        Entry::Item(Text::new("Revert File").into(), FileMessage::RevertFile),
-                        Entry::Item(Text::new("Close Editor").into(), FileMessage::CloseEditor),
-                        Entry::Item(Text::new("Close Folder").into(), FileMessage::CloseFolder),
-                        Entry::Item(Text::new("Close Window").into(), FileMessage::CloseWindow),
+                        Entry::Item(
+                            Text::new("Revert File").into(),
+                            Some(FileMessage::RevertFile),
+                        ),
+                        Entry::Item(
+                            Text::new("Close Editor").into(),
+                            Some(FileMessage::CloseEditor),
+                        ),
+                        Entry::Item(
+                            Text::new("Close Folder").into(),
+                            Some(FileMessage::CloseFolder),
+                        ),
+                        Entry::Item(
+                            Text::new("Close Window").into(),
+                            Some(FileMessage::CloseWindow),
+                        ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Exit").into(), FileMessage::Exit),
+                        Entry::Item(Text::new("Exit").into(), Some(FileMessage::Exit)),
                     ],
                 )
                 .map(MenuMessage::File),
@@ -163,33 +243,36 @@ impl Sandbox for MenuExample {
                 Section::new(
                     Text::new("Edit"),
                     vec![
-                        Entry::Item(Text::new("Undo").into(), EditMessage::Undo),
-                        Entry::Item(Text::new("Redo").into(), EditMessage::Redo),
+                        Entry::Item(Text::new("Undo").into(), Some(EditMessage::Undo)),
+                        Entry::Item(Text::new("Redo").into(), Some(EditMessage::Redo)),
                         Entry::Separator,
-                        Entry::Item(Text::new("Cut").into(), EditMessage::Cut),
-                        Entry::Item(Text::new("Copy").into(), EditMessage::Copy),
-                        Entry::Item(Text::new("Paste").into(), EditMessage::Paste),
+                        Entry::Item(Text::new("Cut").into(), Some(EditMessage::Cut)),
+                        Entry::Item(Text::new("Copy").into(), Some(EditMessage::Copy)),
+                        Entry::Item(Text::new("Paste").into(), Some(EditMessage::Paste)),
                         Entry::Separator,
-                        Entry::Item(Text::new("Find").into(), EditMessage::Find),
-                        Entry::Item(Text::new("Replace").into(), EditMessage::Replace),
+                        Entry::Item(Text::new("Find").into(), Some(EditMessage::Find)),
+                        Entry::Item(Text::new("Replace").into(), Some(EditMessage::Replace)),
                         Entry::Separator,
-                        Entry::Item(Text::new("Find in Files").into(), EditMessage::FindInFiles),
+                        Entry::Item(
+                            Text::new("Find in Files").into(),
+                            Some(EditMessage::FindInFiles),
+                        ),
                         Entry::Item(
                             Text::new("Replace in Files").into(),
-                            EditMessage::ReplaceInFiles,
+                            Some(EditMessage::ReplaceInFiles),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Toggle Line Comment").into(),
-                            EditMessage::ToggleLineComment,
+                            Some(EditMessage::ToggleLineComment),
                         ),
                         Entry::Item(
                             Text::new("Toggle Block Comment").into(),
-                            EditMessage::ToggleBlockComment,
+                            Some(EditMessage::ToggleBlockComment),
                         ),
                         Entry::Item(
                             Text::new("Emmet: Expand Abbreviation").into(),
-                            EditMessage::EmmetExpandAbbreviation,
+                            Some(EditMessage::EmmetExpandAbbreviation),
                         ),
                     ],
                 )
@@ -199,69 +282,72 @@ impl Sandbox for MenuExample {
                 Section::new(
                     Text::new("Selection"),
                     vec![
-                        Entry::Item(Text::new("Select All").into(), SelectionMessage::SelectAll),
+                        Entry::Item(
+                            Text::new("Select All").into(),
+                            Some(SelectionMessage::SelectAll),
+                        ),
                         Entry::Item(
                             Text::new("Expand Selection").into(),
-                            SelectionMessage::ExpandSelection,
+                            Some(SelectionMessage::ExpandSelection),
                         ),
                         Entry::Item(
                             Text::new("Shrink Selection").into(),
-                            SelectionMessage::ShrinkSelection,
+                            Some(SelectionMessage::ShrinkSelection),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Copy Line Up").into(),
-                            SelectionMessage::CopyLineUp,
+                            Some(SelectionMessage::CopyLineUp),
                         ),
                         Entry::Item(
                             Text::new("Copy Line Down").into(),
-                            SelectionMessage::CopyLineDown,
+                            Some(SelectionMessage::CopyLineDown),
                         ),
                         Entry::Item(
                             Text::new("Move Line Up").into(),
-                            SelectionMessage::MoveLineUp,
+                            Some(SelectionMessage::MoveLineUp),
                         ),
                         Entry::Item(
                             Text::new("Move Line Down").into(),
-                            SelectionMessage::MoveLineDown,
+                            Some(SelectionMessage::MoveLineDown),
                         ),
                         Entry::Item(
                             Text::new("Duplicate Selection").into(),
-                            SelectionMessage::DuplicateSelection,
+                            Some(SelectionMessage::DuplicateSelection),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Add Cursor Above").into(),
-                            SelectionMessage::AddCursorAbove,
+                            Some(SelectionMessage::AddCursorAbove),
                         ),
                         Entry::Item(
                             Text::new("Add Cursor Below").into(),
-                            SelectionMessage::AddCursorBelow,
+                            Some(SelectionMessage::AddCursorBelow),
                         ),
                         Entry::Item(
                             Text::new("Add Cursors to Line Ends").into(),
-                            SelectionMessage::AddCursorsToLineEnds,
+                            Some(SelectionMessage::AddCursorsToLineEnds),
                         ),
                         Entry::Item(
                             Text::new("Add Next Occurrence").into(),
-                            SelectionMessage::AddNextOccurrence,
+                            Some(SelectionMessage::AddNextOccurrence),
                         ),
                         Entry::Item(
                             Text::new("Add Previous Occurrence").into(),
-                            SelectionMessage::AddPreviousOccurrence,
+                            Some(SelectionMessage::AddPreviousOccurrence),
                         ),
                         Entry::Item(
                             Text::new("Select All Occurrences").into(),
-                            SelectionMessage::SelectAllOccurrences,
+                            Some(SelectionMessage::SelectAllOccurrences),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Switch to Ctrl+Click for Multi-Cursor").into(),
-                            SelectionMessage::SwitchToCtrlClickForMultiCursor,
+                            Some(SelectionMessage::SwitchToCtrlClickForMultiCursor),
                         ),
                         Entry::Item(
                             Text::new("Column Selection Mode").into(),
-                            SelectionMessage::ColumnSelectionMode,
+                            Some(SelectionMessage::ColumnSelectionMode),
                         ),
                     ],
                 )
@@ -273,72 +359,78 @@ impl Sandbox for MenuExample {
                     vec![
                         Entry::Item(
                             Text::new("Command Palette...").into(),
-                            ViewMessage::CommandPalette,
+                            Some(ViewMessage::CommandPalette),
                         ),
-                        Entry::Item(Text::new("Open View...").into(), ViewMessage::OpenView),
+                        Entry::Item(
+                            Text::new("Open View...").into(),
+                            Some(ViewMessage::OpenView),
+                        ),
                         Entry::Separator,
                         Entry::Group(
                             Text::new("Appearance").into(),
                             vec![
                                 Entry::Item(
                                     Text::new("Full Screen").into(),
-                                    AppearanceMessage::FullScreen,
+                                    Some(AppearanceMessage::FullScreen),
                                 ),
                                 Entry::Item(
                                     Text::new("Zen Mode [Ctrl+K Z]").into(),
-                                    AppearanceMessage::ZenMode,
+                                    Some(AppearanceMessage::ZenMode),
                                 ),
                                 Entry::Item(
                                     Text::new("Centered Layout").into(),
-                                    AppearanceMessage::CenteredLayout,
+                                    Some(AppearanceMessage::CenteredLayout),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Show Menu Bar").into(),
-                                    AppearanceMessage::ShowMenuBar,
+                                    Some(AppearanceMessage::ShowMenuBar),
                                 ),
                                 Entry::Item(
                                     Text::new("Show Side Bar").into(),
-                                    AppearanceMessage::ShowSideBar,
+                                    Some(AppearanceMessage::ShowSideBar),
                                 ),
                                 Entry::Item(
                                     Text::new("Show Status Bar").into(),
-                                    AppearanceMessage::ShowStatusBar,
+                                    Some(AppearanceMessage::ShowStatusBar),
                                 ),
                                 Entry::Item(
                                     Text::new("Show Activity Bar").into(),
-                                    AppearanceMessage::ShowActivityBar,
+                                    Some(AppearanceMessage::ShowActivityBar),
                                 ),
                                 Entry::Item(
                                     Text::new("Show Editor Bar").into(),
-                                    AppearanceMessage::ShowEditorBar,
+                                    Some(AppearanceMessage::ShowEditorBar),
                                 ),
                                 Entry::Item(
                                     Text::new("Show Panel Bar").into(),
-                                    AppearanceMessage::ShowPanelBar,
+                                    Some(AppearanceMessage::ShowPanelBar),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Move Side Bar Right").into(),
-                                    AppearanceMessage::MoveSideBarRight,
+                                    Some(AppearanceMessage::MoveSideBarRight),
                                 ),
                                 Entry::Item(
                                     Text::new("Move Panel Left").into(),
-                                    AppearanceMessage::MovePanelLeft,
+                                    Some(AppearanceMessage::MovePanelLeft),
                                 ),
                                 Entry::Item(
                                     Text::new("Move Panel Right").into(),
-                                    AppearanceMessage::MovePanelRight,
+                                    Some(AppearanceMessage::MovePanelRight),
                                 ),
                                 Entry::Separator,
-                                Entry::Item(Text::new("Zoom In").into(), AppearanceMessage::ZoomIn),
+                                Entry::Item(
+                                    Text::new("Zoom In").into(),
+                                    Some(AppearanceMessage::ZoomIn),
+                                ),
                                 Entry::Item(
                                     Text::new("Zoom Out").into(),
-                                    AppearanceMessage::ZoomOut,
+                                    Some(AppearanceMessage::ZoomOut),
                                 ),
                                 Entry::Item(
                                     Text::new("Reset Zoom [Ctrl+NumPad0").into(),
-                                    AppearanceMessage::ResetZoom,
+                                    Some(AppearanceMessage::ResetZoom),
                                 ),
                             ],
                         )
@@ -348,92 +440,104 @@ impl Sandbox for MenuExample {
                             vec![
                                 Entry::Item(
                                     Text::new("Split Up").into(),
-                                    EditorLayoutMessage::SplitUp,
+                                    Some(EditorLayoutMessage::SplitUp),
                                 ),
                                 Entry::Item(
                                     Text::new("Split Down").into(),
-                                    EditorLayoutMessage::SplitDown,
+                                    Some(EditorLayoutMessage::SplitDown),
                                 ),
                                 Entry::Item(
                                     Text::new("Split Left").into(),
-                                    EditorLayoutMessage::SplitLeft,
+                                    Some(EditorLayoutMessage::SplitLeft),
                                 ),
                                 Entry::Item(
                                     Text::new("Split Right").into(),
-                                    EditorLayoutMessage::SplitRight,
+                                    Some(EditorLayoutMessage::SplitRight),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Single").into(),
-                                    EditorLayoutMessage::Single,
+                                    Some(EditorLayoutMessage::Single),
                                 ),
                                 Entry::Item(
                                     Text::new("Two Columns").into(),
-                                    EditorLayoutMessage::TwoColumns,
+                                    Some(EditorLayoutMessage::TwoColumns),
                                 ),
                                 Entry::Item(
                                     Text::new("Three Columns").into(),
-                                    EditorLayoutMessage::ThreeColumns,
+                                    Some(EditorLayoutMessage::ThreeColumns),
                                 ),
                                 Entry::Item(
                                     Text::new("Two Rows").into(),
-                                    EditorLayoutMessage::TwoRows,
+                                    Some(EditorLayoutMessage::TwoRows),
                                 ),
                                 Entry::Item(
                                     Text::new("Three Rows").into(),
-                                    EditorLayoutMessage::ThreeRows,
+                                    Some(EditorLayoutMessage::ThreeRows),
                                 ),
                                 Entry::Item(
                                     Text::new("Grid (2x2)").into(),
-                                    EditorLayoutMessage::Grid,
+                                    Some(EditorLayoutMessage::Grid),
                                 ),
                                 Entry::Item(
                                     Text::new("Two Rows Right").into(),
-                                    EditorLayoutMessage::TwoRowsRight,
+                                    Some(EditorLayoutMessage::TwoRowsRight),
                                 ),
                                 Entry::Item(
                                     Text::new("Two Columns Bottom").into(),
-                                    EditorLayoutMessage::TwoColumnsBottom,
+                                    Some(EditorLayoutMessage::TwoColumnsBottom),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Flip Layout").into(),
-                                    EditorLayoutMessage::FlipLayout,
+                                    Some(EditorLayoutMessage::FlipLayout),
                                 ),
                             ],
                         )
                         .map(ViewMessage::EditorLayout),
                         Entry::Separator,
-                        Entry::Item(Text::new("Explorer").into(), ViewMessage::Explorer),
-                        Entry::Item(Text::new("Search").into(), ViewMessage::Search),
-                        Entry::Item(Text::new("SCM [Ctrl+Shift+G G]").into(), ViewMessage::Scm),
-                        Entry::Item(Text::new("Run").into(), ViewMessage::Run),
-                        Entry::Item(Text::new("Extensions").into(), ViewMessage::Extensions),
+                        Entry::Item(Text::new("Explorer").into(), Some(ViewMessage::Explorer)),
+                        Entry::Item(Text::new("Search").into(), Some(ViewMessage::Search)),
+                        Entry::Item(
+                            Text::new("SCM [Ctrl+Shift+G G]").into(),
+                            Some(ViewMessage::Scm),
+                        ),
+                        Entry::Item(Text::new("Run").into(), Some(ViewMessage::Run)),
+                        Entry::Item(
+                            Text::new("Extensions").into(),
+                            Some(ViewMessage::Extensions),
+                        ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Output [Ctrl+K Ctrl+H]").into(),
-                            ViewMessage::Output,
+                            Some(ViewMessage::Output),
                         ),
-                        Entry::Item(Text::new("Debug Console").into(), ViewMessage::DebugConsole),
-                        Entry::Item(Text::new("Terminal").into(), ViewMessage::Terminal),
-                        Entry::Item(Text::new("Problems").into(), ViewMessage::Problems),
+                        Entry::Item(
+                            Text::new("Debug Console").into(),
+                            Some(ViewMessage::DebugConsole),
+                        ),
+                        Entry::Item(Text::new("Terminal").into(), Some(ViewMessage::Terminal)),
+                        Entry::Item(Text::new("Problems").into(), Some(ViewMessage::Problems)),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Toggle Word Wrap").into(),
-                            ViewMessage::ToggleWordWrap,
+                            Some(ViewMessage::ToggleWordWrap),
                         ),
-                        Entry::Item(Text::new("Show Minimap").into(), ViewMessage::ShowMinimap),
+                        Entry::Item(
+                            Text::new("Show Minimap").into(),
+                            Some(ViewMessage::ShowMinimap),
+                        ),
                         Entry::Item(
                             Text::new("Show Breadcrumbs").into(),
-                            ViewMessage::ShowBreadcrumbs,
+                            Some(ViewMessage::ShowBreadcrumbs),
                         ),
                         Entry::Item(
                             Text::new("Render Whitespace").into(),
-                            ViewMessage::RenderWhitespace,
+                            Some(ViewMessage::RenderWhitespace),
                         ),
                         Entry::Item(
                             Text::new("Render Control Characters").into(),
-                            ViewMessage::RenderControlCharacters,
+                            Some(ViewMessage::RenderControlCharacters),
                         ),
                     ],
                 )
@@ -443,11 +547,18 @@ impl Sandbox for MenuExample {
                 Section::new(
                     Text::new("Go"),
                     vec![
-                        Entry::Item(Text::new("Back").into(), GoMessage::Back),
-                        Entry::Item(Text::new("Forward").into(), GoMessage::Forward),
+                        Entry::Item(Text::new("Back").into(), Some(GoMessage::Back)),
+                        Entry::Item(
+                            Text::new("Forward").into(),
+                            if self.config.enable_forward {
+                                Some(GoMessage::Forward)
+                            } else {
+                                None
+                            },
+                        ),
                         Entry::Item(
                             Text::new("Last Edit Location [Ctrl+K Ctrl+Q]").into(),
-                            GoMessage::LastEditLocation,
+                            Some(GoMessage::LastEditLocation),
                         ),
                         Entry::Separator,
                         Entry::Group(
@@ -455,39 +566,39 @@ impl Sandbox for MenuExample {
                             vec![
                                 Entry::Item(
                                     Text::new("Next Editor").into(),
-                                    SwitchEditorMessage::NextEditor,
+                                    Some(SwitchEditorMessage::NextEditor),
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Editor").into(),
-                                    SwitchEditorMessage::PreviousEditor,
+                                    Some(SwitchEditorMessage::PreviousEditor),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Next Used Editor").into(),
-                                    SwitchEditorMessage::NextUsedEditor,
+                                    Some(SwitchEditorMessage::NextUsedEditor),
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Used Editor").into(),
-                                    SwitchEditorMessage::PreviousUsedEditor,
+                                    Some(SwitchEditorMessage::PreviousUsedEditor),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Next Editor in Group [Ctrl+K Ctrl+PageDown]").into(),
-                                    SwitchEditorMessage::NextEditorInGroup,
+                                    Some(SwitchEditorMessage::NextEditorInGroup),
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Editor in Group [Ctrl+K Ctrl+PageUp]")
                                         .into(),
-                                    SwitchEditorMessage::PreviousEditorInGroup,
+                                    Some(SwitchEditorMessage::PreviousEditorInGroup),
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Next Used Editor in Group").into(),
-                                    SwitchEditorMessage::NextUsedEditorInGroup,
+                                    Some(SwitchEditorMessage::NextUsedEditorInGroup),
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Used Editor in Group").into(),
-                                    SwitchEditorMessage::PreviousUsedEditorInGroup,
+                                    Some(SwitchEditorMessage::PreviousUsedEditorInGroup),
                                 ),
                             ],
                         )
@@ -497,101 +608,163 @@ impl Sandbox for MenuExample {
                             vec![
                                 Entry::Item(
                                     Text::new("Group 1").into(),
-                                    SwitchGroupMessage::Group1,
+                                    Some(SwitchGroupMessage::Group1),
                                 ),
                                 Entry::Item(
                                     Text::new("Group 2").into(),
-                                    SwitchGroupMessage::Group2,
+                                    Some(SwitchGroupMessage::Group2),
                                 ),
                                 Entry::Item(
                                     Text::new("Group 3").into(),
-                                    SwitchGroupMessage::Group3,
+                                    if self.config.enable_group_3 {
+                                        Some(SwitchGroupMessage::Group3)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Group 4").into(),
-                                    SwitchGroupMessage::Group4,
+                                    if self.config.enable_group_4 {
+                                        Some(SwitchGroupMessage::Group4)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Group 5").into(),
-                                    SwitchGroupMessage::Group5,
+                                    if self.config.enable_group_5 {
+                                        Some(SwitchGroupMessage::Group5)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Next Group").into(),
-                                    SwitchGroupMessage::NextGroup,
+                                    if self.config.enable_next_group {
+                                        Some(SwitchGroupMessage::NextGroup)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Previous Group").into(),
-                                    SwitchGroupMessage::PreviousGroup,
+                                    if self.config.enable_previous_group {
+                                        Some(SwitchGroupMessage::PreviousGroup)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Separator,
                                 Entry::Item(
                                     Text::new("Group Left [Ctrl+K Ctrl+LeftArrow]").into(),
-                                    SwitchGroupMessage::GroupLeft,
+                                    if self.config.enable_group_left {
+                                        Some(SwitchGroupMessage::GroupLeft)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Group Right [Ctrl+K Ctrl+RightArrow]").into(),
-                                    SwitchGroupMessage::GroupRight,
+                                    if self.config.enable_group_right {
+                                        Some(SwitchGroupMessage::GroupRight)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Group Above [Ctrl+K Ctrl+UpArrow]").into(),
-                                    SwitchGroupMessage::GroupAbove,
+                                    if self.config.enable_group_above {
+                                        Some(SwitchGroupMessage::GroupAbove)
+                                    } else {
+                                        None
+                                    },
                                 ),
                                 Entry::Item(
                                     Text::new("Group Below [Ctrl+K Ctrl+DownArrow]").into(),
-                                    SwitchGroupMessage::GroupBelow,
+                                    if self.config.enable_group_below {
+                                        Some(SwitchGroupMessage::GroupBelow)
+                                    } else {
+                                        None
+                                    },
                                 ),
                             ],
                         )
                         .map(GoMessage::SwitchGroup),
                         Entry::Separator,
-                        Entry::Item(Text::new("Go to File...").into(), GoMessage::GoToFile),
+                        Entry::Item(Text::new("Go to File...").into(), Some(GoMessage::GoToFile)),
                         Entry::Item(
                             Text::new("Go to Symbol in Workspace...").into(),
-                            GoMessage::GoToSymbolInWorkspace,
+                            Some(GoMessage::GoToSymbolInWorkspace),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Go to Symbol in Editor...").into(),
-                            GoMessage::GoToSymbolInEditor,
+                            Some(GoMessage::GoToSymbolInEditor),
                         ),
                         Entry::Item(
                             Text::new("Go to Definition").into(),
-                            GoMessage::GoToDefinition,
+                            if self.config.enable_go_to_definition {
+                                Some(GoMessage::GoToDefinition)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Go to Declaration").into(),
-                            GoMessage::GoToDeclaration,
+                            if self.config.enable_go_to_declaration {
+                                Some(GoMessage::GoToDeclaration)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Go to Type Definition").into(),
-                            GoMessage::GoToTypeDefinition,
+                            if self.config.enable_go_to_type_definition {
+                                Some(GoMessage::GoToTypeDefinition)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Go to Implementations").into(),
-                            GoMessage::GoToImplementations,
+                            if self.config.enable_go_to_implementations {
+                                Some(GoMessage::GoToImplementations)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Go to References").into(),
-                            GoMessage::GoToReferences,
+                            if self.config.enable_go_to_references {
+                                Some(GoMessage::GoToReferences)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Go to Line/Column...").into(),
-                            GoMessage::GoToLineColumn,
+                            Some(GoMessage::GoToLineColumn),
                         ),
-                        Entry::Item(Text::new("Go to Bracket").into(), GoMessage::GoToBracket),
+                        Entry::Item(
+                            Text::new("Go to Bracket").into(),
+                            Some(GoMessage::GoToBracket),
+                        ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Next Problem").into(), GoMessage::NextProblem),
+                        Entry::Item(
+                            Text::new("Next Problem").into(),
+                            Some(GoMessage::NextProblem),
+                        ),
                         Entry::Item(
                             Text::new("Previous Problem").into(),
-                            GoMessage::PreviousProblem,
+                            Some(GoMessage::PreviousProblem),
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Next Change").into(), GoMessage::NextChange),
+                        Entry::Item(Text::new("Next Change").into(), Some(GoMessage::NextChange)),
                         Entry::Item(
                             Text::new("Previous Change").into(),
-                            GoMessage::PreviousChange,
+                            Some(GoMessage::PreviousChange),
                         ),
                     ],
                 )
@@ -603,57 +776,97 @@ impl Sandbox for MenuExample {
                     vec![
                         Entry::Item(
                             Text::new("Start Debugging").into(),
-                            RunMessage::StartDebugging,
+                            Some(RunMessage::StartDebugging),
                         ),
                         Entry::Item(
                             Text::new("Run Without Debugging").into(),
-                            RunMessage::RunWithoutDebugging,
+                            Some(RunMessage::RunWithoutDebugging),
                         ),
                         Entry::Item(
                             Text::new("Stop Debugging").into(),
-                            RunMessage::StopDebugging,
+                            if self.config.enable_stop_debugging {
+                                Some(RunMessage::StopDebugging)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Restart Debugging").into(),
-                            RunMessage::RestartDebugging,
+                            if self.config.enable_restart_debugging {
+                                Some(RunMessage::RestartDebugging)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Open Configurations").into(),
-                            RunMessage::OpenConfigurations,
+                            if self.config.enable_open_configuration {
+                                Some(RunMessage::OpenConfigurations)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Add Configuration...").into(),
-                            RunMessage::AddConfiguration,
+                            Some(RunMessage::AddConfiguration),
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Step Over").into(), RunMessage::StepOver),
-                        Entry::Item(Text::new("Step Into").into(), RunMessage::StepInto),
-                        Entry::Item(Text::new("Step Out").into(), RunMessage::StepOut),
-                        Entry::Item(Text::new("Continue").into(), RunMessage::Continue),
+                        Entry::Item(
+                            Text::new("Step Over").into(),
+                            if self.config.enable_step_over {
+                                Some(RunMessage::StepOver)
+                            } else {
+                                None
+                            },
+                        ),
+                        Entry::Item(
+                            Text::new("Step Into").into(),
+                            if self.config.enable_step_into {
+                                Some(RunMessage::StepInto)
+                            } else {
+                                None
+                            },
+                        ),
+                        Entry::Item(
+                            Text::new("Step Out").into(),
+                            if self.config.enable_step_out {
+                                Some(RunMessage::StepOut)
+                            } else {
+                                None
+                            },
+                        ),
+                        Entry::Item(
+                            Text::new("Continue").into(),
+                            if self.config.enable_continue {
+                                Some(RunMessage::Continue)
+                            } else {
+                                None
+                            },
+                        ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Toggle Breakpoint").into(),
-                            RunMessage::ToggleBreakpoint,
+                            Some(RunMessage::ToggleBreakpoint),
                         ),
                         Entry::Group(
                             Text::new("New Breakpoint").into(),
                             vec![
                                 Entry::Item(
                                     Text::new("Conditional Breakpoint...").into(),
-                                    NewBreakpointMessage::ConditionalBreakpoint,
+                                    Some(NewBreakpointMessage::ConditionalBreakpoint),
                                 ),
                                 Entry::Item(
                                     Text::new("Inline Breakpoint").into(),
-                                    NewBreakpointMessage::InlineBreakpoint,
+                                    Some(NewBreakpointMessage::InlineBreakpoint),
                                 ),
                                 Entry::Item(
                                     Text::new("Function Breakpoint...").into(),
-                                    NewBreakpointMessage::FunctionBreakpoint,
+                                    Some(NewBreakpointMessage::FunctionBreakpoint),
                                 ),
                                 Entry::Item(
                                     Text::new("Logpoint...").into(),
-                                    NewBreakpointMessage::Logpoint,
+                                    Some(NewBreakpointMessage::Logpoint),
                                 ),
                             ],
                         )
@@ -661,20 +874,20 @@ impl Sandbox for MenuExample {
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Enable All Breakpoints").into(),
-                            RunMessage::EnableAllBreakpoints,
+                            Some(RunMessage::EnableAllBreakpoints),
                         ),
                         Entry::Item(
                             Text::new("Disable All Breakpoints").into(),
-                            RunMessage::DisableAllBreakpoints,
+                            Some(RunMessage::DisableAllBreakpoints),
                         ),
                         Entry::Item(
                             Text::new("Remove All Breakpoints").into(),
-                            RunMessage::RemoveAllBreakpoints,
+                            Some(RunMessage::RemoveAllBreakpoints),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Install Additional Debuggers...").into(),
-                            RunMessage::InstallAdditionalDebuggers,
+                            Some(RunMessage::InstallAdditionalDebuggers),
                         ),
                     ],
                 )
@@ -686,47 +899,62 @@ impl Sandbox for MenuExample {
                     vec![
                         Entry::Item(
                             Text::new("New Terminal").into(),
-                            TerminalMessage::NewTerminal,
+                            Some(TerminalMessage::NewTerminal),
                         ),
                         Entry::Item(
                             Text::new("Split Terminal").into(),
-                            TerminalMessage::SplitTerminal,
+                            Some(TerminalMessage::SplitTerminal),
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("Run Task...").into(), TerminalMessage::RunTask),
+                        Entry::Item(
+                            Text::new("Run Task...").into(),
+                            Some(TerminalMessage::RunTask),
+                        ),
                         Entry::Item(
                             Text::new("Run Build Task...").into(),
-                            TerminalMessage::RunBuildTask,
+                            Some(TerminalMessage::RunBuildTask),
                         ),
                         Entry::Item(
                             Text::new("Run Active File").into(),
-                            TerminalMessage::RunActiveFile,
+                            Some(TerminalMessage::RunActiveFile),
                         ),
                         Entry::Item(
                             Text::new("Run Selected Text").into(),
-                            TerminalMessage::RunSelectedText,
+                            Some(TerminalMessage::RunSelectedText),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Show Running Tasks...").into(),
-                            TerminalMessage::ShowRunningTasks,
+                            if self.config.enable_show_running_tasks {
+                                Some(TerminalMessage::ShowRunningTasks)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Restart Running Tasks...").into(),
-                            TerminalMessage::RestartRunningTasks,
+                            if self.config.enable_restart_running_tasks {
+                                Some(TerminalMessage::RestartRunningTasks)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Item(
                             Text::new("Terminate Tasks...").into(),
-                            TerminalMessage::TerminateTasks,
+                            if self.config.enable_terminate_tasks {
+                                Some(TerminalMessage::TerminateTasks)
+                            } else {
+                                None
+                            },
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Configure Tasks...").into(),
-                            TerminalMessage::ConfigureTasks,
+                            Some(TerminalMessage::ConfigureTasks),
                         ),
                         Entry::Item(
                             Text::new("Configure Default Build Task...").into(),
-                            TerminalMessage::ConfigureDefaultBuildTasks,
+                            Some(TerminalMessage::ConfigureDefaultBuildTasks),
                         ),
                     ],
                 )
@@ -736,61 +964,70 @@ impl Sandbox for MenuExample {
                 Section::new(
                     Text::new("Help"),
                     vec![
-                        Entry::Item(Text::new("Welcome").into(), HelpMessage::Welcome),
+                        Entry::Item(Text::new("Welcome").into(), Some(HelpMessage::Welcome)),
                         Entry::Item(
                             Text::new("Interactive Playground").into(),
-                            HelpMessage::InteractivePlayground,
+                            Some(HelpMessage::InteractivePlayground),
                         ),
                         Entry::Item(
                             Text::new("Documentation").into(),
-                            HelpMessage::Documentation,
+                            Some(HelpMessage::Documentation),
                         ),
-                        Entry::Item(Text::new("Release Notes").into(), HelpMessage::ReleaseNotes),
+                        Entry::Item(
+                            Text::new("Release Notes").into(),
+                            Some(HelpMessage::ReleaseNotes),
+                        ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Keyboard Shortcuts Reference [Ctrl+K Ctrl+R]").into(),
-                            HelpMessage::KeyboardShortCutsReference,
+                            Some(HelpMessage::KeyboardShortCutsReference),
                         ),
                         Entry::Item(
                             Text::new("Introductory Videos").into(),
-                            HelpMessage::IntroductoryVideos,
+                            Some(HelpMessage::IntroductoryVideos),
                         ),
                         Entry::Item(
                             Text::new("Tips and Tricks").into(),
-                            HelpMessage::TipsAndTricks,
+                            Some(HelpMessage::TipsAndTricks),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Join Us on Twitter").into(),
-                            HelpMessage::JoinUsOnTwitter,
+                            Some(HelpMessage::JoinUsOnTwitter),
                         ),
                         Entry::Item(
                             Text::new("Search Feature Requests").into(),
-                            HelpMessage::SearchFeatureRequests,
+                            Some(HelpMessage::SearchFeatureRequests),
                         ),
-                        Entry::Item(Text::new("Report Issue").into(), HelpMessage::ReportIssue),
+                        Entry::Item(
+                            Text::new("Report Issue").into(),
+                            Some(HelpMessage::ReportIssue),
+                        ),
                         Entry::Separator,
-                        Entry::Item(Text::new("View License").into(), HelpMessage::ViewLicense),
+                        Entry::Item(
+                            Text::new("View License").into(),
+                            Some(HelpMessage::ViewLicense),
+                        ),
                         Entry::Item(
                             Text::new("Privacy Statement").into(),
-                            HelpMessage::PrivacyStatement,
+                            Some(HelpMessage::PrivacyStatement),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Toggle Developer Tools").into(),
-                            HelpMessage::ToggleDeveloperTools,
+                            Some(HelpMessage::ToggleDeveloperTools),
                         ),
                         Entry::Item(
                             Text::new("Open Process Explorer").into(),
-                            HelpMessage::OpenProcessExplorer,
+                            Some(HelpMessage::OpenProcessExplorer),
                         ),
                         Entry::Separator,
                         Entry::Item(
                             Text::new("Download Available Update").into(),
-                            HelpMessage::DownloadAvailableUpdate,
+                            Some(HelpMessage::DownloadAvailableUpdate),
                         ),
                         Entry::Separator,
-                        Entry::Item(Text::new("About").into(), HelpMessage::About),
+                        Entry::Item(Text::new("About").into(), Some(HelpMessage::About)),
                     ],
                 )
                 .map(MenuMessage::Help),

--- a/src/core/menu.rs
+++ b/src/core/menu.rs
@@ -1,0 +1,94 @@
+//! A menu bar.
+//!
+//! *This API requires the following crate features to be activated: `menu`*
+use crate::menu::{Entry, Section};
+
+/// Return an expanded list of paths based on the given stack of indices.
+///
+/// For example: If the stack contains [4, 5, 2] the result would be
+/// [[4], [4, 5], [4, 5, 2]].
+#[must_use]
+pub fn stack_to_path_list(stack: &[usize]) -> Vec<&[usize]> {
+    let mut list = Vec::new();
+
+    for i in 0..stack.len() {
+        list.push(&stack[0..=i])
+    }
+
+    list
+}
+
+/// Returns the entry of the section specified by the given path.
+///
+/// # Panics
+///
+/// Will panic if the entry does not exists or the path is invalid.
+#[must_use]
+pub fn get_entry<'a, Message, Renderer>(
+    section: &'a Section<'a, Message, Renderer>,
+    path: &[usize],
+) -> &'a Entry<'a, Message, Renderer> {
+    let entries = &section.entries;
+    get_entry_internal(entries, &path[1..])
+}
+
+/// Returns the entry of the section specified by the given path.
+///
+/// # Panics
+///
+/// Will panic if the entry does not exists or the path is invalid.
+fn get_entry_internal<'a, Message, Renderer>(
+    entries: &'a [Entry<'a, Message, Renderer>],
+    path: &[usize],
+) -> &'a Entry<'a, Message, Renderer> {
+    if path.len() == 1 {
+        &entries[path[0]]
+    } else {
+        match &entries[path[0]] {
+            Entry::Group(_, entries) => get_entry_internal(entries, &path[1..]),
+            _ => unreachable!("Entry is not a group"),
+        }
+    }
+}
+
+/// Returns a list of all entries in the given section grouped together by its
+/// `Entry::Group` based on the given path.
+///
+/// # Panics
+///
+/// Will panic if the given path is invalid.
+#[must_use]
+pub fn get_entry_list<'a, Message, Renderer>(
+    section: &'a Section<'a, Message, Renderer>,
+    path: &[usize],
+) -> Vec<&'a Vec<Entry<'a, Message, Renderer>>> {
+    let mut entries = Vec::new();
+    entries.push(&section.entries);
+    get_entry_list_internal(&section.entries, &path[1..], &mut entries);
+
+    entries
+}
+
+/// Returns a list of all entries in the given section grouped together by its
+/// `Entry::Group` based on the given path.
+///
+/// # Panics
+///
+/// Will panic if the given path is invalid.
+fn get_entry_list_internal<'a, Message, Renderer>(
+    entries: &'a [Entry<'a, Message, Renderer>],
+    path: &[usize],
+    collection: &mut Vec<&'a Vec<Entry<'a, Message, Renderer>>>,
+) {
+    if path.is_empty() {
+        return;
+    }
+
+    match &entries[path[0]] {
+        Entry::Group(_, entries) => {
+            collection.push(entries);
+            get_entry_list_internal(entries, &path[1..], collection);
+        }
+        _ => unreachable!("Entry is not a group"),
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,9 @@ pub mod clock;
 #[cfg(all(feature = "color_picker", not(target_arch = "wasm32")))]
 pub mod color;
 
+#[cfg(all(feature = "menu", not(target_arch = "wasm32")))]
+pub mod menu;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod overlay;
 

--- a/src/graphics/menu.rs
+++ b/src/graphics/menu.rs
@@ -194,6 +194,7 @@ where
 }
 
 /// Draws the entries.
+#[allow(clippy::too_many_lines)]
 fn draw_entries<'a, Message, B>(
     renderer: &mut Renderer<B>,
     env: &DrawEnvironment<'_, Defaults, HashMap<StyleState, Style>, ()>,

--- a/src/graphics/menu.rs
+++ b/src/graphics/menu.rs
@@ -151,13 +151,14 @@ where
 
         let mut mouse_interaction = mouse::Interaction::default();
 
-        let mut selected_childs: Vec<Option<usize>> = state.stack.iter()
-            .skip(1)
-            .map(|i| Some(*i))
-            .fold(Vec::with_capacity(state.stack.len()), |mut v, i| {
-                v.push(i);
-                v
-            });
+        let mut selected_childs: Vec<Option<usize>> =
+            state.stack.iter().skip(1).map(|i| Some(*i)).fold(
+                Vec::with_capacity(state.stack.len()),
+                |mut v, i| {
+                    v.push(i);
+                    v
+                },
+            );
         selected_childs.push(None);
 
         let primitives = children
@@ -246,7 +247,9 @@ where
             };
 
             let mut style_state = StyleState::Active;
-            if (layout.bounds().contains(env.cursor_position) && selected_child.is_none()) || Some(i) == selected_child {
+            if (layout.bounds().contains(env.cursor_position) && selected_child.is_none())
+                || Some(i) == selected_child
+            {
                 style_state = style_state.max(StyleState::Hovered);
             }
             if is_disabled {
@@ -320,6 +323,6 @@ where
             offset: Vector::new(0, 0),
             content: Box::new(Primitive::Group { primitives }),
         },
-        mouse_interaction
+        mouse_interaction,
     )
 }

--- a/src/graphics/menu.rs
+++ b/src/graphics/menu.rs
@@ -246,7 +246,7 @@ where
                 Entry::Item(_, message) => message.is_none(),
                 Entry::Toggle(_, _, message) => message.is_none(),
                 Entry::Group(_, entries) => entries.is_empty(),
-                Entry::Separator => false,
+                Entry::Separator => true,
             };
 
             let mut style_state = StyleState::Active;
@@ -288,8 +288,21 @@ where
                     &label_layout.bounds(),
                 ),
                 Entry::Separator => {
-                    // TODO
-                    (Primitive::None, mouse::Interaction::default())
+                    (
+                        Primitive::Quad {
+                            bounds: Rectangle {
+                                x: bounds.x + env.style_sheet[&style_state].separator_horizontal_margin,
+                                y: bounds.center_y(),
+                                width: bounds.width - 2.0*env.style_sheet[&style_state].separator_horizontal_margin,
+                                height: env.style_sheet[&style_state].separator_width,
+                            },
+                            background: env.style_sheet[&style_state].separator_color.into(),
+                            border_radius: env.style_sheet[&style_state].separator_radius,
+                            border_width: 0.0,
+                            border_color: Color::TRANSPARENT,
+                        },
+                        mouse::Interaction::default()
+                    )
                 }
             };
 

--- a/src/graphics/menu.rs
+++ b/src/graphics/menu.rs
@@ -287,23 +287,22 @@ where
                     env.cursor_position,
                     &label_layout.bounds(),
                 ),
-                Entry::Separator => {
-                    (
-                        Primitive::Quad {
-                            bounds: Rectangle {
-                                x: bounds.x + env.style_sheet[&style_state].separator_horizontal_margin,
-                                y: bounds.center_y(),
-                                width: bounds.width - 2.0*env.style_sheet[&style_state].separator_horizontal_margin,
-                                height: env.style_sheet[&style_state].separator_width,
-                            },
-                            background: env.style_sheet[&style_state].separator_color.into(),
-                            border_radius: env.style_sheet[&style_state].separator_radius,
-                            border_width: 0.0,
-                            border_color: Color::TRANSPARENT,
+                Entry::Separator => (
+                    Primitive::Quad {
+                        bounds: Rectangle {
+                            x: bounds.x + env.style_sheet[&style_state].separator_horizontal_margin,
+                            y: bounds.center_y(),
+                            width: bounds.width
+                                - 2.0 * env.style_sheet[&style_state].separator_horizontal_margin,
+                            height: env.style_sheet[&style_state].separator_width,
                         },
-                        mouse::Interaction::default()
-                    )
-                }
+                        background: env.style_sheet[&style_state].separator_color.into(),
+                        border_radius: env.style_sheet[&style_state].separator_radius,
+                        border_width: 0.0,
+                        border_color: Color::TRANSPARENT,
+                    },
+                    mouse::Interaction::default(),
+                ),
             };
 
             let checkmark_icon = if let Entry::Toggle(_, checked, _) = entry {

--- a/src/graphics/menu.rs
+++ b/src/graphics/menu.rs
@@ -1,0 +1,293 @@
+//! A menu bar.
+//!
+//! *This API requires the following crate features to be activated: `menu`*
+use std::collections::HashMap;
+
+use iced_graphics::{
+    backend, defaults, Backend, Background, Color, Defaults, Primitive, Rectangle, Renderer, Vector,
+};
+use iced_native::mouse;
+
+pub use crate::native::menu::{Entry, Section, State};
+use crate::{
+    core::{menu::get_entry_list, renderer::DrawEnvironment},
+    native::menu,
+    style::{
+        menu::{Style, StyleSheet},
+        style_state::StyleState,
+    },
+};
+
+use super::icons::{Icon, ICON_FONT};
+
+/// A menu bar.
+///
+/// This is an alias of the `iced_native` `Menu` with an `iced_wgpu::Renderer`.
+pub type Menu<'a, Message, Backend> = menu::Menu<'a, Message, Renderer<Backend>>;
+
+impl<B> menu::Renderer for Renderer<B>
+where
+    B: Backend + backend::Text,
+{
+    type Style = Box<dyn StyleSheet>;
+
+    fn draw<Message>(
+        &mut self,
+        env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        sections: &[menu::Section<'_, Message, Self>],
+    ) -> Self::Output {
+        let bounds = env.layout.bounds();
+        let children = env.layout.children();
+
+        let mut style: HashMap<StyleState, Style> = HashMap::new();
+        let _ = style.insert(StyleState::Active, env.style_sheet.active());
+        let _ = style.insert(StyleState::Selected, env.style_sheet.selected());
+        let _ = style.insert(StyleState::Hovered, env.style_sheet.hovered());
+        let _ = style.insert(StyleState::Focused, env.style_sheet.focused());
+
+        let mut mouse_interaction = mouse::Interaction::default();
+
+        let mut style_state = StyleState::Active;
+        if bounds.contains(env.cursor_position) {
+            style_state = style_state.max(StyleState::Hovered);
+        }
+
+        // TODO: Implement proper shadow support
+        let shadow = if style[&style_state].shadow_offset == Vector::default() {
+            Primitive::None
+        } else {
+            Primitive::Quad {
+                bounds: Rectangle {
+                    x: bounds.x + style[&style_state].shadow_offset.x,
+                    y: bounds.y + style[&style_state].shadow_offset.y,
+                    ..bounds
+                },
+                background: Background::Color([0.0, 0.0, 0.0, 0.5].into()),
+                border_radius: style[&style_state].border_radius,
+                border_width: style[&style_state].border_width,
+                border_color: Color::TRANSPARENT,
+            }
+        };
+
+        let background = Primitive::Quad {
+            bounds,
+            background: style[&style_state].background,
+            border_radius: style[&style_state].border_radius,
+            border_width: style[&style_state].border_width,
+            border_color: style[&style_state].border_color,
+        };
+
+        let mut section_primitives: Vec<Primitive> = sections
+            .iter()
+            .zip(children)
+            .map(|(section, layout)| {
+                let style_state = if layout.bounds().contains(env.cursor_position) {
+                    StyleState::Hovered
+                } else {
+                    StyleState::Active
+                };
+
+                let background =
+                    style[&style_state]
+                        .label_background
+                        .map_or(Primitive::None, |background| Primitive::Quad {
+                            bounds: layout.bounds(),
+                            background,
+                            border_radius: 0.0,
+                            border_width: 0.0,
+                            border_color: Color::TRANSPARENT,
+                        });
+
+                let (label, new_mouse_interaction) = section.label.draw(
+                    self,
+                    &Defaults {
+                        text: defaults::Text {
+                            color: style[&style_state].text_color,
+                        },
+                    },
+                    layout,
+                    env.cursor_position,
+                    env.viewport.expect("A viewport should exist for Menu"),
+                );
+
+                mouse_interaction = mouse_interaction.max(new_mouse_interaction);
+
+                Primitive::Group {
+                    primitives: vec![background, label],
+                }
+            })
+            .collect();
+
+        let mut primitives = vec![shadow, background];
+        primitives.append(&mut section_primitives);
+
+        (Primitive::Group { primitives }, mouse_interaction)
+    }
+}
+
+impl<B> crate::native::overlay::menu::Renderer for Renderer<B>
+where
+    B: Backend + backend::Text,
+{
+    type Style = Box<dyn StyleSheet>;
+
+    fn draw<Message>(
+        &mut self,
+        env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        state: &State,
+        section: &Section<'_, Message, Self>,
+    ) -> Self::Output {
+        let children = env.layout.children();
+
+        let mut style: HashMap<StyleState, Style> = HashMap::new();
+        let _ = style.insert(StyleState::Active, env.style_sheet.active());
+        let _ = style.insert(StyleState::Selected, env.style_sheet.selected());
+        let _ = style.insert(StyleState::Hovered, env.style_sheet.hovered());
+        let _ = style.insert(StyleState::Focused, env.style_sheet.focused());
+
+        let mut mouse_interaction = mouse::Interaction::default();
+
+        let primitives = children
+            .into_iter()
+            .zip(get_entry_list(section, &state.stack))
+            .map(|(layout, entries)| {
+                let (primitive, new_mouse_interaction) = draw_entries(
+                    self,
+                    &DrawEnvironment {
+                        defaults: env.defaults,
+                        layout,
+                        cursor_position: env.cursor_position,
+                        style_sheet: &style,
+                        viewport: env.viewport,
+                        focus: (),
+                    },
+                    state,
+                    //&section.entries,
+                    entries,
+                );
+
+                mouse_interaction = mouse_interaction.max(new_mouse_interaction);
+
+                primitive
+            })
+            .collect();
+
+        (Primitive::Group { primitives }, mouse_interaction)
+    }
+}
+
+/// Draws the entries.
+fn draw_entries<'a, Message, B>(
+    renderer: &mut Renderer<B>,
+    env: &DrawEnvironment<'_, Defaults, HashMap<StyleState, Style>, ()>,
+    _state: &State,
+    entries: &[Entry<'a, Message, Renderer<B>>],
+) -> (Primitive, mouse::Interaction)
+where
+    B: Backend + backend::Text,
+{
+    let bounds = env.layout.bounds();
+
+    let mut mouse_interaction = mouse::Interaction::default();
+
+    // TODO: Implement proper shadow support
+    let shadow = if env.style_sheet[&StyleState::Active].overlay_shadow_offset == Vector::default()
+    {
+        Primitive::None
+    } else {
+        Primitive::Quad {
+            bounds: Rectangle {
+                x: bounds.x + env.style_sheet[&StyleState::Active].overlay_shadow_offset.x,
+                y: bounds.y + env.style_sheet[&StyleState::Active].overlay_shadow_offset.y,
+                ..bounds
+            },
+            background: Background::Color([0.0, 0.0, 0.0, 0.5].into()),
+            border_radius: env.style_sheet[&StyleState::Active].overlay_border_radius,
+            border_width: env.style_sheet[&StyleState::Active].overlay_border_width,
+            border_color: Color::TRANSPARENT,
+        }
+    };
+
+    let background = Primitive::Quad {
+        bounds,
+        background: env.style_sheet[&StyleState::Active].overlay_background,
+        border_radius: env.style_sheet[&StyleState::Active].overlay_border_radius,
+        border_width: env.style_sheet[&StyleState::Active].overlay_border_width,
+        border_color: env.style_sheet[&StyleState::Active].overlay_border_color,
+    };
+
+    let mut entry_primitives: Vec<Primitive> = entries
+        .iter()
+        .zip(env.layout.children())
+        .map(|(entry, layout)| {
+            let bounds = layout.bounds();
+
+            let style_state = if layout.bounds().contains(env.cursor_position) {
+                StyleState::Hovered
+            } else {
+                StyleState::Active
+            };
+
+            let background = env.style_sheet[&style_state]
+                .overlay_label_background
+                .map_or(Primitive::None, |background| Primitive::Quad {
+                    bounds,
+                    background,
+                    border_radius: 0.0,
+                    border_width: 0.0,
+                    border_color: Color::TRANSPARENT,
+                });
+
+            let label_layout = layout
+                .children()
+                .next()
+                .expect("Graphics: Entry should have a label layout");
+            let (primitive, new_mouse_interaction) = match entry {
+                Entry::Item(element, _) | Entry::Group(element, _) => element.draw(
+                    renderer,
+                    &Defaults {
+                        text: defaults::Text {
+                            color: env.style_sheet[&style_state].overlay_text_color,
+                        },
+                    },
+                    label_layout,
+                    env.cursor_position,
+                    &label_layout.bounds(),
+                ),
+                Entry::Separator => {
+                    // TODO
+                    (Primitive::None, mouse::Interaction::default())
+                }
+            };
+
+            let group_icon = match entry {
+                Entry::Group(_, _) => Primitive::Text {
+                    content: Icon::CaretRightFill.into(),
+                    bounds: Rectangle {
+                        x: bounds.x + bounds.width - 8.0, // TODO
+                        y: bounds.center_y(),
+                        width: 16.0,
+                        height: 16.0,
+                    },
+                    color: env.style_sheet[&style_state].overlay_text_color,
+                    size: 16.0,
+                    font: ICON_FONT,
+                    horizontal_alignment: iced_graphics::HorizontalAlignment::Center,
+                    vertical_alignment: iced_graphics::VerticalAlignment::Center,
+                },
+                _ => Primitive::None,
+            };
+
+            mouse_interaction = mouse_interaction.max(new_mouse_interaction);
+
+            Primitive::Group {
+                primitives: vec![background, primitive, group_icon],
+            }
+        })
+        .collect();
+
+    let mut primitives = vec![shadow, background];
+    primitives.append(&mut entry_primitives);
+
+    (Primitive::Group { primitives }, mouse_interaction)
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -32,6 +32,11 @@ pub mod icon_text;
 #[cfg(feature = "icon_text")]
 pub use icon_text::IconText;
 
+#[cfg(feature = "menu")]
+pub mod menu;
+#[cfg(feature = "menu")]
+pub use menu::Menu;
+
 #[cfg(feature = "modal")]
 pub mod modal;
 #[cfg(feature = "modal")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap,
-    clippy::module_name_repetitions,
+    clippy::module_name_repetitions
 )]
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -76,6 +76,10 @@ mod platform {
     #[doc(no_inline)]
     #[cfg(feature = "floating_button")]
     pub use {crate::graphics::floating_button, floating_button::FloatingButton};
+
+    #[doc(no_inline)]
+    #[cfg(feature = "menu")]
+    pub use {crate::graphics::menu, menu::Menu};
 
     #[doc(no_inline)]
     #[cfg(feature = "modal")]

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -34,14 +34,14 @@ use super::overlay::MenuOverlay;
 ///     .push(Section::new(
 ///         Text::new("Section 1"),
 ///         vec![
-///             Entry::Item(Text::new("Entry 1").into(), Message::Entry1),
-///             Entry::Item(Text::new("Entry 2").into(), Message::Entry2),
+///             Entry::Item(Text::new("Entry 1").into(), Some(Message::Entry1)),
+///             Entry::Item(Text::new("Entry 2").into(), Some(Message::Entry2)),
 ///         ]
 ///     ))
 ///     .push(Section::new(
 ///         Text::new("Section2"),
 ///         vec![
-///             Entry::Item(Text::new("Entry 3").into(), Message::Entry3),
+///             Entry::Item(Text::new("Entry 3").into(), Some(Message::Entry3)),
 ///         ]
 ///     ));
 /// ```

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -357,6 +357,12 @@ pub enum Entry<'a, Message, Renderer> {
     /// and a message that is send when the item is pressed.
     /// If the message is none the item will be disabled.
     Item(Element<'a, Message, Renderer>, Option<Message>),
+    /// An [`Entry`] item that can be toggled.
+    Toggle(
+        Element<'a, Message, Renderer>,
+        bool,
+        Option<Box<dyn Fn(bool) -> Message + 'static>>,
+    ),
     /// A group of [`Entry`](Entry)s holding an [`Element`](iced_native::Element) for
     /// it's label.
     /// If the vector is empty the group will be disabled.
@@ -382,6 +388,14 @@ impl<'a, Message, Renderer: iced_native::Renderer> Entry<'a, Message, Renderer> 
     {
         match self {
             Entry::Item(label, message) => Entry::Item(label.map(f), message.map(f)),
+            Entry::Toggle(label, toggled, message) => Entry::Toggle(
+                label.map(f),
+                toggled,
+                message.map(|m| {
+                    // TODO: I can't believe that this actually works...
+                    Box::new(move |b: bool| f(m(b))) as Box<dyn Fn(bool) -> B>
+                }),
+            ),
             Entry::Group(label, entries) => Entry::Group(
                 label.map(f),
                 entries.into_iter().map(|entry| entry.map(f)).collect(),

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -1,0 +1,398 @@
+//! A menu bar.
+//!
+//! *This API requires the following crate features to be activated: `menu`*
+use std::hash::Hash;
+
+use iced_graphics::{Point, Size};
+use iced_native::{
+    event, layout, mouse, overlay, row, touch, Clipboard, Element, Event, Layout, Length, Row,
+    Widget,
+};
+
+use crate::core::renderer::DrawEnvironment;
+
+use super::overlay::MenuOverlay;
+
+/// A menu bar.
+///
+/// # Example
+/// ```
+/// # use iced_aw::menu::{State, Section, Entry};
+/// # use iced_native::{Text, renderer::Null};
+/// #
+/// # pub type Menu<'a, Message> = iced_aw::native::Menu<'a, Message, Null>;
+/// #[derive(Clone, Debug)]
+/// enum Message {
+///     Entry1,
+///     Entry2,
+///     Entry3,    
+/// }
+///
+/// let mut menu_state = State::new();
+///
+/// let menu = Menu::new(&mut menu_state)
+///     .push(Section::new(
+///         Text::new("Section 1"),
+///         vec![
+///             Entry::Item(Text::new("Entry 1").into(), Message::Entry1),
+///             Entry::Item(Text::new("Entry 2").into(), Message::Entry2),
+///         ]
+///     ))
+///     .push(Section::new(
+///         Text::new("Section2"),
+///         vec![
+///             Entry::Item(Text::new("Entry 3").into(), Message::Entry3),
+///         ]
+///     ));
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct Menu<'a, Message, Renderer>
+where
+    Renderer: self::Renderer,
+{
+    /// The state of the [`Menu`](Menu).
+    state: &'a mut State,
+    /// A vector containing the [`Section`](Section)s of the [`Menu`](Menu).
+    sections: Vec<Section<'a, Message, Renderer>>,
+    /// The width of the [`Menu`](Menu).
+    width: Length,
+    /// The height of the [`Menu`](Menu).
+    height: Length,
+    /// The space between the [`Section`](Section)s of the [`Menu`](Menu).
+    space: f32,
+    /// The padding around the [`Section`](Section)s.
+    padding: f32,
+    /// The [`Style`](crate::style::menu::Style) of the [`Menu`](Menu).
+    style: Renderer::Style,
+}
+
+impl<'a, Message, Renderer> Menu<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
+    /// Creates a new [`Menu`](Menu) with an empty list of sections.
+    ///
+    /// It expects:
+    ///     * a mutable reference to the [`Menu`](Menu)'s [`State`](State).
+    pub fn new(state: &'a mut State) -> Self {
+        Menu::with_sections(state, Vec::new())
+    }
+
+    /// Creates a new [`Menu`](Menu) with the given list of sections.
+    ///
+    /// It expects:
+    ///     * a mutable reference to the [`Menu`](Menu)'s [`State`](State).
+    ///     * a vector containing the sections.
+    pub fn with_sections(
+        state: &'a mut State,
+        sections: Vec<Section<'a, Message, Renderer>>,
+    ) -> Self {
+        Self {
+            state,
+            sections,
+            width: Length::Fill,
+            height: Length::Shrink,
+            space: 10.0,
+            padding: 5.0,
+            style: Renderer::Style::default(),
+        }
+    }
+
+    /// Pushes a [`Section`](Section) to the [`Menu`](Menu).
+    pub fn push<S>(mut self, section: S) -> Self
+    where
+        S: Into<Section<'a, Message, Renderer>>,
+    {
+        self.sections.push(section.into());
+        self
+    }
+}
+
+impl<'a, Message, Renderer> Widget<Message, Renderer> for Menu<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer + row::Renderer + crate::native::overlay::menu::Renderer,
+{
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
+    fn layout(&self, renderer: &Renderer, limits: &iced_native::layout::Limits) -> layout::Node {
+        let limits = limits.clone().width(self.width()).height(self.height());
+
+        let width = Row::<Message, Renderer>::new()
+            .width(Length::Fill)
+            .layout(renderer, &limits)
+            .bounds()
+            .width;
+
+        let section_limits = limits.clone().pad(self.padding).width(Length::Shrink);
+
+        let mut entries: Vec<layout::Node> = self
+            .sections
+            .iter()
+            .map(|section| section.label.layout(renderer, &section_limits))
+            .collect();
+
+        let mut offset = self.padding;
+
+        entries.iter_mut().for_each(|entry| {
+            entry.move_to(Point::new(offset, entry.bounds().y + self.padding));
+            offset += entry.bounds().width + self.space
+        });
+
+        let max_height = entries
+            .iter()
+            .map(layout::Node::bounds)
+            .map(|bounds| bounds.height)
+            //.max()
+            // https://stackoverflow.com/a/28446718
+            .fold(0.0, |a: f32, b: f32| a.max(b));
+
+        layout::Node::with_children(Size::new(width, max_height + 2.0 * self.padding), entries)
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        _messages: &mut Vec<Message>,
+        _renderer: &Renderer,
+        _clipboard: Option<&dyn Clipboard>,
+    ) -> event::Status {
+        let bounds = layout.bounds();
+        let children = layout.children();
+
+        if self.state.stack.is_empty() {
+            let (status, index) = self
+                .sections
+                .iter_mut()
+                .zip(children)
+                .enumerate()
+                .map(|(i, (_entry, layout))| {
+                    let mut status = (event::Status::Ignored, 0);
+                    match event {
+                        Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+                        | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                            if layout.bounds().contains(cursor_position) {
+                                status = (event::Status::Captured, i);
+                            }
+                        }
+                        _ => {}
+                    }
+                    status
+                })
+                .find(|(status, _)| *status == event::Status::Captured)
+                .unwrap_or((event::Status::Ignored, 0));
+
+            if status == event::Status::Captured {
+                self.state.stack.push(index);
+            }
+
+            status
+        } else {
+            if bounds.contains(cursor_position) {
+                let element = self
+                    .sections
+                    .iter()
+                    .zip(children)
+                    .enumerate()
+                    .find(|(_, (_, layout))| layout.bounds().contains(cursor_position));
+
+                if let Some((i, _)) = element {
+                    self.state.stack.clear();
+                    self.state.stack.push(i);
+                }
+            }
+
+            event::Status::Ignored
+        }
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        defaults: &Renderer::Defaults,
+        layout: iced_native::Layout<'_>,
+        cursor_position: iced_graphics::Point,
+        viewport: &iced_graphics::Rectangle,
+    ) -> Renderer::Output {
+        <Renderer as self::Renderer>::draw(
+            renderer,
+            DrawEnvironment {
+                defaults,
+                layout,
+                cursor_position,
+                style_sheet: &self.style,
+                viewport: Some(viewport),
+                focus: (),
+            },
+            &self.sections,
+        )
+    }
+
+    fn hash_layout(&self, state: &mut iced_native::Hasher) {
+        #[allow(clippy::missing_docs_in_private_items)]
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
+
+        self.sections
+            .iter()
+            .for_each(|section| section.label.hash_layout(state));
+    }
+
+    fn overlay(&mut self, layout: Layout<'_>) -> Option<overlay::Element<'_, Message, Renderer>> {
+        if self.state.stack.is_empty() {
+            return None;
+        }
+
+        let index = *self.state.stack.first()?;
+
+        let bounds = layout.bounds();
+        let entry_bounds = layout.children().nth(index)?.bounds();
+
+        let position = Point::new(entry_bounds.x, bounds.y + bounds.height);
+
+        Some(MenuOverlay::new(&mut self.state, self.sections.get(index)?, position).overlay())
+    }
+}
+
+/// The renderer of  a [`Menu`](Menu).
+///
+/// Your renderer will need to implement this trait before being
+/// able to use a [`Menu`](Menu) in your user interface.
+pub trait Renderer: iced_native::Renderer {
+    /// The style supported by this renderer.
+    type Style: Default;
+
+    /// Draws a [`Menu`](Menu).
+    fn draw<Message>(
+        &mut self,
+        env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        section: &[Section<'_, Message, Self>],
+    ) -> Self::Output;
+}
+
+impl Renderer for iced_native::renderer::Null {
+    type Style = ();
+
+    fn draw<Message>(
+        &mut self,
+        _env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        _section: &[Section<'_, Message, Self>],
+    ) -> Self::Output {
+    }
+}
+
+/// The state of the [`Menu`](Menu).
+#[derive(Debug, Default)]
+pub struct State {
+    /// The stack containing the indices that build a path to the opened [`Entry`](Entry).
+    pub(crate) stack: Vec<usize>,
+}
+
+impl State {
+    /// Creates a new [`State`](State).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { stack: Vec::new() }
+    }
+}
+
+/// A section of the menu containing a list of entries.
+#[allow(missing_debug_implementations)]
+pub struct Section<'a, Message, Renderer> {
+    /// The label of the [`Section`](Section).
+    pub(crate) label: Element<'a, Message, Renderer>,
+    /// A vector containing the [entries](Entry) of the [`Section`](Section).
+    pub(crate) entries: Vec<Entry<'a, Message, Renderer>>,
+}
+
+impl<'a, Message, Renderer> Section<'a, Message, Renderer> {
+    /// Creates a new [`Section`](Section).
+    ///
+    /// It expects:
+    ///     * A label that is displayed on the [`Menu`](Menu) bar.
+    ///     * A vector containing the group of entries this [`Section`](Section) has.
+    pub fn new<E>(label: E, entries: Vec<Entry<'a, Message, Renderer>>) -> Self
+    where
+        E: Into<Element<'a, Message, Renderer>>,
+    {
+        Self {
+            label: label.into(),
+            entries,
+        }
+    }
+
+    /// Applies a transformation to the produced message of the [`Section`](Section).
+    ///
+    /// Take a look into the [`Element`](iced_native::Element) documentation for
+    /// more information.
+    pub fn map<F, B>(self, f: F) -> Section<'a, B, Renderer>
+    where
+        Message: 'static,
+        Renderer: 'a + iced_native::Renderer,
+        B: 'static,
+        F: 'static + Copy + Fn(Message) -> B,
+    {
+        Section::new(
+            self.label.map(f),
+            self.entries.into_iter().map(|e| e.map(f)).collect(),
+        )
+    }
+}
+
+/// An [`Entry`](Entry) of a [`Section`](Section) or `[Entry](Entry)::Group`.
+#[allow(missing_debug_implementations)]
+pub enum Entry<'a, Message, Renderer> {
+    /// An [`Entry`] item holding an [`Element`](iced_native::Element) for it's label
+    /// and a message that is send when the item is pressed.
+    Item(Element<'a, Message, Renderer>, Message),
+    /// A group of [`Entry`](Entry)s holding an [`Element`](iced_native::Element) for
+    /// it's label.
+    Group(
+        Element<'a, Message, Renderer>,
+        Vec<Entry<'a, Message, Renderer>>,
+    ),
+    /// A separator.
+    Separator,
+}
+
+impl<'a, Message, Renderer: iced_native::Renderer> Entry<'a, Message, Renderer> {
+    /// Applies a transformation to the produced message of the [`Element`](Element).
+    ///
+    /// Take a look into the [`Element`](iced_native::Element) documentation for
+    /// more information.
+    pub fn map<F, B>(self, f: F) -> Entry<'a, B, Renderer>
+    where
+        Message: 'static,
+        Renderer: 'a,
+        B: 'static,
+        F: 'static + Copy + Fn(Message) -> B,
+    {
+        match self {
+            Entry::Item(label, message) => Entry::Item(label.map(f), f(message)),
+            Entry::Group(label, entries) => Entry::Group(
+                label.map(f),
+                entries.into_iter().map(|entry| entry.map(f)).collect(),
+            ),
+            Entry::Separator => Entry::Separator,
+        }
+    }
+}
+
+impl<'a, Message, Renderer> From<Menu<'a, Message, Renderer>> for Element<'a, Message, Renderer>
+where
+    Message: 'a + Clone,
+    Renderer: 'a + self::Renderer + row::Renderer + crate::native::overlay::menu::Renderer,
+{
+    fn from(menu: Menu<'a, Message, Renderer>) -> Self {
+        Element::new(menu)
+    }
+}

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -162,9 +162,9 @@ where
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
-        _messages: &mut Vec<Message>,
         _renderer: &Renderer,
-        _clipboard: Option<&dyn Clipboard>,
+        _clipboard: &mut dyn Clipboard,
+        _messages: &mut Vec<Message>,
     ) -> event::Status {
         let bounds = layout.bounds();
         let children = layout.children();

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -32,6 +32,11 @@ pub mod icon_text;
 #[cfg(feature = "icon_text")]
 pub use icon_text::IconText;
 
+#[cfg(feature = "menu")]
+pub mod menu;
+#[cfg(feature = "menu")]
+pub use menu::Menu;
+
 #[cfg(feature = "modal")]
 pub mod modal;
 #[cfg(feature = "modal")]

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -115,9 +115,9 @@ where
         event: Event,
         layout: Layout<'_>,
         cursor_position: Point,
-        messages: &mut Vec<Message>,
         _renderer: &Renderer,
-        _clipboard: Option<&dyn Clipboard>,
+        _clipboard: &mut dyn Clipboard,
+        messages: &mut Vec<Message>,
     ) -> event::Status {
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -87,7 +87,11 @@ where
         layout_entries(
             renderer,
             &self.section.entries,
-            bounds,
+            //bounds,
+            Size::new(
+                bounds.width,
+                bounds.height - position.y,
+            ),
             self.padding,
             Point::new(position.x, 0.0),
             &self.state.stack[1..],
@@ -308,6 +312,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     );
 
     node.move_to(position);
+    vertical_bounce(&mut node, bounds);
 
     if !path.is_empty() {
         if let Entry::Group(_, entries) = &entries[path[0]] {
@@ -327,4 +332,13 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     }
 
     nodes.push(node);
+}
+
+fn vertical_bounce(node: &mut layout::Node, bounds: Size) {
+    if node.bounds().y + node.bounds().height > bounds.height {
+        node.move_to(Point::new(
+            node.bounds().x,
+            (node.bounds().y + ( bounds.height - (node.bounds().y + node.bounds().height) )).max(0.0),
+        ))
+    }
 }

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -23,6 +23,8 @@ use crate::{
 pub const GROUP_ICON_SIZE: f32 = 16.0;
 /// The size of the little checkmark icon for `Entry::Touble`.
 pub const TOGGLE_ICON_SIZE: f32 = 16.0;
+/// The vertical padding of a group of entries.
+pub const VERTICAL_PADDING: f32 = 8.0;
 
 /// The overlay of the [`Menu`](crate::native::Menu).
 #[allow(missing_debug_implementations)]
@@ -309,7 +311,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
         .map(|entry| layout::Node::with_children(Size::new(max_width, max_height), vec![entry]))
         .collect();
 
-    let mut offset = 0.0;
+    let mut offset = VERTICAL_PADDING;
 
     entry_nodes.iter_mut().for_each(|entry| {
         entry.move_to(Point::new(entry.bounds().x, offset));
@@ -319,7 +321,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     let mut node = layout::Node::with_children(
         Size::new(
             max_width,
-            entry_nodes.iter().map(|entry| entry.bounds().height).sum(),
+            entry_nodes.iter().map(|entry| entry.bounds().height).sum::<f32>() + 2.0 * VERTICAL_PADDING,
         ),
         entry_nodes,
     );

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -20,7 +20,9 @@ use crate::{
 };
 
 /// The size of the little arrow marking an `Entry::Group`.
-const GROUP_ICON_SIZE: f32 = 16.0;
+pub const GROUP_ICON_SIZE: f32 = 16.0;
+/// The size of the little checkmark icon for `Entry::Touble`.
+pub const TOGGLE_ICON_SIZE: f32 = 16.0;
 
 /// The overlay of the [`Menu`](crate::native::Menu).
 #[allow(missing_debug_implementations)]
@@ -159,6 +161,16 @@ where
                             }
                             _ => {}
                         },
+                        Entry::Toggle(_, b, message) => match event {
+                            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+                            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                                if let Some(message) = message {
+                                    messages.push((message)(!*b));
+                                    path = Vec::new();
+                                }
+                            }
+                            _ => {}
+                        },
                         Entry::Group(_, entries) => {
                             if !entries.is_empty() {
                                 path = entry_path;
@@ -258,7 +270,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     let mut entry_nodes: Vec<layout::Node> = entries
         .iter()
         .map(|entry| match entry {
-            Entry::Item(element, _) | Entry::Group(element, _) => {
+            Entry::Item(element, _) | Entry::Toggle(element, _, _) | Entry::Group(element, _) => {
                 element.layout(renderer, &entry_limits)
             }
             Entry::Separator => {
@@ -270,7 +282,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
 
     entry_nodes.iter_mut().for_each(|entry| {
         entry.move_to(Point::new(
-            entry.bounds().x + padding,
+            entry.bounds().x + padding + TOGGLE_ICON_SIZE,
             entry.bounds().y + padding,
         ))
     });
@@ -282,6 +294,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
         // https://stackoverflow.com/a/28446718
         .fold(0.0, |a: f32, b: f32| a.max(b))
         + 2.0 * padding
+        + TOGGLE_ICON_SIZE
         + GROUP_ICON_SIZE;
     let max_height = entry_nodes
         .iter()

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -148,13 +148,17 @@ where
                         Entry::Item(_, message) => match event {
                             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                             | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                                messages.push(message.to_owned());
-                                path = Vec::new();
+                                if let Some(message) = message {
+                                    messages.push(message.to_owned());
+                                    path = Vec::new();
+                                }
                             }
                             _ => {}
                         },
-                        Entry::Group(_, _) => {
-                            path = entry_path;
+                        Entry::Group(_, entries) => {
+                            if !entries.is_empty() {
+                                path = entry_path;
+                            }
                         }
                         Entry::Separator => {}
                     }

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -1,0 +1,326 @@
+//! A menu bar.
+//!
+//! *This API requires the following crate features to be activated: `menu`*
+use std::hash::Hash;
+
+use iced_graphics::{Point, Size};
+use iced_native::{
+    event,
+    layout::{self, Limits},
+    mouse, overlay, touch, Clipboard, Event, Layout, Length,
+};
+
+use crate::{
+    core::{
+        menu::{get_entry, stack_to_path_list},
+        renderer::DrawEnvironment,
+    },
+    menu::{Entry, State},
+    native::menu::Section,
+};
+
+/// The size of the little arrow marking an `Entry::Group`.
+const GROUP_ICON_SIZE: f32 = 16.0;
+
+/// The overlay of the [`Menu`](crate::native::Menu).
+#[allow(missing_debug_implementations)]
+pub struct MenuOverlay<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
+    /// The state of the [`Menu`](crate::native::Menu).
+    state: &'a mut State,
+    /// The [`Section`](crate::native::menu::Section) that is displayed on this overlay.
+    section: &'a Section<'a, Message, Renderer>,
+    /// The padding around each entry.
+    padding: f32,
+    /// The position of the [`Section`](crate::native::menu::Section).
+    position: Point,
+    /// The style of the [`Menu`](crate::native::Menu)/[`MenuOverlay`](MenuOverlay).
+    style: Renderer::Style,
+}
+
+impl<'a, Message, Renderer> MenuOverlay<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
+    /// Creates a new [`MenuOverlay`](MenuOverlay) on the given position, displaying
+    /// the specified section.
+    pub fn new(
+        state: &'a mut State,
+        section: &'a Section<'a, Message, Renderer>,
+        position: Point,
+    ) -> Self {
+        Self {
+            state,
+            section,
+            padding: 3.0,
+            position,
+            style: Renderer::Style::default(),
+        }
+    }
+
+    /// Turn this [`MenuOverlay`](MenuOverlay) into an overlay [`Element`](overlay::Element).
+    #[must_use]
+    pub fn overlay(self) -> overlay::Element<'a, Message, Renderer> {
+        overlay::Element::new(self.position, Box::new(self))
+    }
+}
+
+impl<'a, Message, Renderer> iced_native::Overlay<Message, Renderer>
+    for MenuOverlay<'a, Message, Renderer>
+where
+    Message: Clone,
+    Renderer: self::Renderer,
+{
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        bounds: iced_graphics::Size,
+        position: Point,
+    ) -> layout::Node {
+        let mut nodes = Vec::new();
+        let offset_y = position.y;
+
+        layout_entries(
+            renderer,
+            &self.section.entries,
+            bounds,
+            self.padding,
+            Point::new(position.x, 0.0),
+            &self.state.stack[1..],
+            &mut nodes,
+        );
+
+        nodes.reverse();
+
+        let mut node =
+            layout::Node::with_children(Size::new(bounds.width, bounds.height - position.y), nodes);
+
+        node.move_to(Point::new(0.0, offset_y));
+
+        node
+    }
+
+    fn on_event(
+        &mut self,
+        event: Event,
+        layout: Layout<'_>,
+        cursor_position: Point,
+        messages: &mut Vec<Message>,
+        _renderer: &Renderer,
+        _clipboard: Option<&dyn Clipboard>,
+    ) -> event::Status {
+        match event {
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if !layout
+                    .children()
+                    .into_iter()
+                    .any(|layout| layout.bounds().contains(cursor_position))
+                {
+                    self.state.stack.clear();
+                    return event::Status::Captured;
+                }
+            }
+            _ => {}
+        }
+
+        let children = layout.children();
+
+        let path_list = stack_to_path_list(&self.state.stack);
+
+        let mut new_path = None;
+
+        children.zip(path_list).for_each(|(layout, path)| {
+            layout.children().enumerate().for_each(|(index, layout)| {
+                if layout.bounds().contains(cursor_position) {
+                    // TODO: clean up
+                    let mut path = path.to_vec();
+
+                    let mut entry_path = path.to_vec();
+                    entry_path.push(index);
+                    let entry = get_entry(self.section, &entry_path);
+
+                    match entry {
+                        Entry::Item(_, message) => match event {
+                            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+                            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                                messages.push(message.to_owned());
+                                path = Vec::new();
+                            }
+                            _ => {}
+                        },
+                        Entry::Group(_, _) => {
+                            path = entry_path;
+                        }
+                        Entry::Separator => {}
+                    }
+                    new_path = Some(path);
+                }
+            })
+        });
+
+        if let Some(new_path) = new_path {
+            self.state.stack = new_path;
+        }
+
+        event::Status::Ignored
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        defaults: &Renderer::Defaults,
+        layout: iced_native::Layout<'_>,
+        cursor_position: Point,
+    ) -> Renderer::Output {
+        <Renderer as self::Renderer>::draw(
+            renderer,
+            DrawEnvironment {
+                defaults,
+                layout,
+                cursor_position,
+                style_sheet: &self.style,
+                viewport: None,
+                focus: (),
+            },
+            self.state,
+            self.section,
+        )
+    }
+
+    fn hash_layout(&self, state: &mut iced_native::Hasher, position: Point) {
+        #[allow(clippy::missing_docs_in_private_items)]
+        struct Marker;
+        std::any::TypeId::of::<Marker>().hash(state);
+
+        self.state.stack.hash(state);
+        (position.x as u32).hash(state);
+        (position.y as u32).hash(state);
+    }
+}
+
+/// The renderer of a [`MenuOverlay`](MenuOverlay).
+///
+/// Your renderer will need to implement this trait before being
+/// able to use a [`MenuOverlay`](MenuOverlay) in your user interface.
+pub trait Renderer: iced_native::Renderer {
+    /// The style supported by this renderer.
+    type Style: Default;
+
+    /// Draws a [`MenuOverlay`](MenuOverlay).
+    fn draw<Message>(
+        &mut self,
+        env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        state: &State,
+        section: &Section<'_, Message, Self>,
+    ) -> Self::Output;
+}
+
+impl Renderer for iced_native::renderer::Null {
+    type Style = ();
+
+    fn draw<Message>(
+        &mut self,
+        _env: DrawEnvironment<'_, Self::Defaults, Self::Style, ()>,
+        _state: &State,
+        _section: &Section<'_, Message, Self>,
+    ) -> Self::Output {
+    }
+}
+
+/// Defines the layout of the entries.
+fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
+    renderer: &Renderer,
+    entries: &[Entry<'a, Message, Renderer>],
+    bounds: Size,
+    padding: f32,
+    position: Point,
+    path: &[usize],
+    nodes: &mut Vec<layout::Node>,
+) {
+    let entry_limits = Limits::new(Size::ZERO, bounds)
+        .pad(padding)
+        .width(Length::Shrink)
+        .height(Length::Shrink);
+
+    let mut entry_nodes: Vec<layout::Node> = entries
+        .iter()
+        .map(|entry| match entry {
+            Entry::Item(element, _) | Entry::Group(element, _) => {
+                element.layout(renderer, &entry_limits)
+            }
+            Entry::Separator => {
+                // TODO
+                layout::Node::default()
+            }
+        })
+        .collect();
+
+    entry_nodes.iter_mut().for_each(|entry| {
+        entry.move_to(Point::new(
+            entry.bounds().x + padding,
+            entry.bounds().y + padding,
+        ))
+    });
+
+    let max_width = entry_nodes
+        .iter()
+        .map(|entry| entry.bounds().width)
+        //.max()
+        // https://stackoverflow.com/a/28446718
+        .fold(0.0, |a: f32, b: f32| a.max(b))
+        + 2.0 * padding
+        + GROUP_ICON_SIZE;
+    let max_height = entry_nodes
+        .iter()
+        .map(|entry| entry.bounds().height)
+        //.max()
+        // https://stackoverflow.com/a/28446718
+        .fold(0.0, |a: f32, b: f32| a.max(b))
+        + 2.0 * padding;
+
+    let mut entry_nodes: Vec<layout::Node> = entry_nodes
+        .into_iter()
+        .map(|entry| layout::Node::with_children(Size::new(max_width, max_height), vec![entry]))
+        .collect();
+
+    let mut offset = 0.0;
+
+    entry_nodes.iter_mut().for_each(|entry| {
+        entry.move_to(Point::new(entry.bounds().x, offset));
+        offset += entry.bounds().height;
+    });
+
+    let mut node = layout::Node::with_children(
+        Size::new(
+            max_width,
+            entry_nodes.iter().map(|entry| entry.bounds().height).sum(),
+        ),
+        entry_nodes,
+    );
+
+    node.move_to(position);
+
+    if !path.is_empty() {
+        if let Entry::Group(_, entries) = &entries[path[0]] {
+            layout_entries(
+                renderer,
+                entries,
+                bounds,
+                padding,
+                Point::new(
+                    node.bounds().x + node.bounds().width,
+                    position.y + node.children()[path[0]].bounds().y,
+                ),
+                &path[1..],
+                nodes,
+            );
+        }
+    }
+
+    nodes.push(node);
+}

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -87,10 +87,7 @@ where
         layout_entries(
             renderer,
             &self.section.entries,
-            Size::new(
-                bounds.width,
-                bounds.height - position.y,
-            ),
+            Size::new(bounds.width, bounds.height - position.y),
             self.padding,
             Positioning {
                 position: Point::new(position.x, 0.0),
@@ -346,19 +343,17 @@ fn vertical_bounce(node: &mut layout::Node, bounds: Size) {
     if node.bounds().y + node.bounds().height > bounds.height {
         node.move_to(Point::new(
             node.bounds().x,
-            (node.bounds().y + ( bounds.height - (node.bounds().y + node.bounds().height) )).max(0.0),
+            (node.bounds().y + (bounds.height - (node.bounds().y + node.bounds().height))).max(0.0),
         ))
     }
 }
 
 fn horizontal_bounce(node: &mut layout::Node, bounds: Size, positioning: Positioning) -> bool {
     if node.bounds().x + node.bounds().width > bounds.width || positioning.use_fallback {
-        node.move_to(
-            Point::new(
-                (node.bounds().x - node.bounds().width - positioning.fallback_offset).max(0.0),
-                node.bounds().y
-            )
-        );
+        node.move_to(Point::new(
+            (node.bounds().x - node.bounds().width - positioning.fallback_offset).max(0.0),
+            node.bounds().y,
+        ));
 
         true
     } else {

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -321,7 +321,11 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     let mut node = layout::Node::with_children(
         Size::new(
             max_width,
-            entry_nodes.iter().map(|entry| entry.bounds().height).sum::<f32>() + 2.0 * VERTICAL_PADDING,
+            entry_nodes
+                .iter()
+                .map(|entry| entry.bounds().height)
+                .sum::<f32>()
+                + 2.0 * VERTICAL_PADDING,
         ),
         entry_nodes,
     );

--- a/src/native/overlay/menu.rs
+++ b/src/native/overlay/menu.rs
@@ -352,6 +352,7 @@ fn layout_entries<'a, Message, Renderer: iced_native::Renderer>(
     nodes.push(node);
 }
 
+/// Lets the node vertically bounce at the given bounds.
 fn vertical_bounce(node: &mut layout::Node, bounds: Size) {
     if node.bounds().y + node.bounds().height > bounds.height {
         node.move_to(Point::new(
@@ -361,6 +362,8 @@ fn vertical_bounce(node: &mut layout::Node, bounds: Size) {
     }
 }
 
+/// Lets the node horizontally bounce at the given bounds. The node will be positioned at the other
+/// side of the parent based on the positioning.
 fn horizontal_bounce(node: &mut layout::Node, bounds: Size, positioning: Positioning) -> bool {
     if node.bounds().x + node.bounds().width > bounds.width || positioning.use_fallback {
         node.move_to(Point::new(
@@ -374,9 +377,13 @@ fn horizontal_bounce(node: &mut layout::Node, bounds: Size, positioning: Positio
     }
 }
 
+/// Positioning information for a group of entries.
 #[derive(Clone, Copy)]
 struct Positioning {
+    /// The position of the group.
     position: Point,
+    /// The fallback offset if the group is bouncing horizontally.
     fallback_offset: f32,
+    /// If the fallback should be used.
     use_fallback: bool,
 }

--- a/src/native/overlay/mod.rs
+++ b/src/native/overlay/mod.rs
@@ -15,6 +15,11 @@ pub mod floating_button;
 #[cfg(feature = "floating_button")]
 pub use floating_button::FloatingButtonOverlay;
 
+#[cfg(feature = "menu")]
+pub mod menu;
+#[cfg(feature = "menu")]
+pub use menu::MenuOverlay;
+
 #[cfg(feature = "modal")]
 pub mod modal;
 #[cfg(feature = "modal")]

--- a/src/style/menu.rs
+++ b/src/style/menu.rs
@@ -1,0 +1,121 @@
+//! A menu bar.
+//!
+//! *This API requires the following crate features to be activated: `menu`*
+#[cfg(not(target_arch = "wasm32"))]
+use iced_native::{Background, Color, Vector};
+#[cfg(target_arch = "wasm32")]
+use iced_web::{Background, Color, Vector};
+
+/// The appearance of a [`Menu`](crate::native::Menu).
+#[derive(Clone, Copy, Debug)]
+pub struct Style {
+    /// The shadow offset of the [`Menu`](crate::native::Menu).
+    pub shadow_offset: Vector,
+    /// The background of the [`Menu`](crate::native::Menu).
+    pub background: Background,
+    /// The border radius of the [`Menu`](crate::native::Menu).
+    pub border_radius: f32,
+    /// The border width of the [`Menu`](crate::native::Menu).
+    pub border_width: f32,
+    /// The border color of the [`Menu`](crate::native::Menu).
+    pub border_color: Color,
+    /// The background of the label of the [`Section`](crate::native::menu::Section)s.
+    pub label_background: Option<Background>,
+    /// The text color of the [`Menu`](crate::native::Menu).
+    pub text_color: Color,
+
+    /// The shadow offset of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_shadow_offset: Vector,
+    /// The background  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_background: Background,
+    /// The border radius  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_border_radius: f32,
+    /// The border width  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_border_width: f32,
+    /// The border color  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_border_color: Color,
+    /// The background of the label of the [entries](crate::native::menu::Entry).
+    pub overlay_label_background: Option<Background>,
+    /// The text color  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
+    pub overlay_text_color: Color,
+}
+
+/// The appearance of a [`Menu`](crate::native::Menu).
+pub trait StyleSheet {
+    /// The normal appearance of a [`Menu`](crate::native::Menu).
+    fn active(&self) -> Style;
+
+    /// The appearance when something is selected of the
+    /// [`Menu`](crate::native::Menu) (Currently unused).
+    fn selected(&self) -> Style;
+
+    /// The appearance when something is hovered of the
+    /// [`Menu`](crate::native::Menu).
+    fn hovered(&self) -> Style;
+
+    /// The appearance when something is focused of the
+    /// [`Menu`](crate::native::Menu).
+    fn focused(&self) -> Style;
+}
+
+/// The default appearance of the [`Menu`](crate::native::Menu).
+#[derive(Clone, Copy, Debug)]
+pub struct Default;
+
+impl StyleSheet for Default {
+    fn active(&self) -> Style {
+        Style {
+            shadow_offset: Vector::new(0.0, 1.0),
+            background: Background::Color([0.87, 0.87, 0.87].into()),
+            border_radius: 0.0,
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT,
+            label_background: None,
+            text_color: Color::BLACK,
+
+            overlay_shadow_offset: Vector::new(0.0, 1.0),
+            overlay_background: Background::Color([0.87, 0.87, 0.87].into()),
+            overlay_border_radius: 0.0,
+            overlay_border_width: 1.0,
+            overlay_border_color: [0.0, 0.0, 0.0, 0.5].into(),
+            overlay_label_background: None,
+            overlay_text_color: Color::BLACK,
+        }
+    }
+
+    fn selected(&self) -> Style {
+        Style { ..self.active() }
+    }
+
+    fn hovered(&self) -> Style {
+        let active = self.active();
+
+        Style {
+            label_background: Some(Background::Color([0.9, 0.9, 0.9].into())),
+            overlay_label_background: Some(Background::Color([0.9, 0.9, 0.9].into())),
+
+            ..active
+        }
+    }
+
+    fn focused(&self) -> Style {
+        Style { ..self.active() }
+    }
+}
+
+#[allow(clippy::use_self)]
+impl std::default::Default for Box<dyn StyleSheet> {
+    fn default() -> Self {
+        Box::new(Default)
+    }
+}
+
+#[allow(clippy::use_self)]
+impl<T> From<T> for Box<dyn StyleSheet>
+where
+    T: 'static + StyleSheet,
+{
+    fn from(style: T) -> Self {
+        Box::new(style)
+    }
+}

--- a/src/style/menu.rs
+++ b/src/style/menu.rs
@@ -38,6 +38,15 @@ pub struct Style {
     pub overlay_label_background: Option<Background>,
     /// The text color  of the [`MenuOverlay`](crate::native::overlay::MenuOverlay).
     pub overlay_text_color: Color,
+
+    /// The corner radius of the separator.
+    pub separator_radius: f32,
+    /// The width of the separator.
+    pub separator_width: f32,
+    /// The color of the separator.
+    pub separator_color: Color,
+    /// The horizontal marging of the separator.
+    pub separator_horizontal_margin: f32,
 }
 
 /// The appearance of a [`Menu`](crate::native::Menu).
@@ -84,6 +93,11 @@ impl StyleSheet for Default {
             overlay_border_color: [0.0, 0.0, 0.0, 0.5].into(),
             overlay_label_background: None,
             overlay_text_color: Color::BLACK,
+            
+            separator_radius: 5.0,
+            separator_width: 1.0,
+            separator_color: [0.7, 0.7, 0.7].into(),
+            separator_horizontal_margin: 1.0,
         }
     }
 

--- a/src/style/menu.rs
+++ b/src/style/menu.rs
@@ -56,6 +56,10 @@ pub trait StyleSheet {
     /// The appearance when something is focused of the
     /// [`Menu`](crate::native::Menu).
     fn focused(&self) -> Style;
+
+    /// The appearance when something is disabled of the
+    /// [`Menu`](crate::native::Menu).
+    fn disabled(&self) -> Style;
 }
 
 /// The default appearance of the [`Menu`](crate::native::Menu).
@@ -100,6 +104,14 @@ impl StyleSheet for Default {
 
     fn focused(&self) -> Style {
         Style { ..self.active() }
+    }
+
+    fn disabled(&self) -> Style {
+        Style {
+            text_color: [0.0, 0.0, 0.0, 0.75].into(),
+            overlay_text_color: [0.0, 0.0, 0.0, 0.75].into(),
+            ..self.active()
+        }
     }
 }
 

--- a/src/style/menu.rs
+++ b/src/style/menu.rs
@@ -93,7 +93,7 @@ impl StyleSheet for Default {
             overlay_border_color: [0.0, 0.0, 0.0, 0.5].into(),
             overlay_label_background: None,
             overlay_text_color: Color::BLACK,
-            
+
             separator_radius: 5.0,
             separator_width: 1.0,
             separator_color: [0.7, 0.7, 0.7].into(),

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -20,6 +20,9 @@ pub mod color_picker;
 #[cfg(feature = "date_picker")]
 pub mod date_picker;
 
+#[cfg(feature = "menu")]
+pub mod menu;
+
 #[cfg(feature = "modal")]
 pub mod modal;
 

--- a/src/style/style_state.rs
+++ b/src/style/style_state.rs
@@ -11,4 +11,6 @@ pub enum StyleState {
     Hovered,
     /// Use the focused style
     Focused,
+    /// Use the disabled style
+    Disabled,
 }


### PR DESCRIPTION
First draft of a `Menu` widget.

![menu](https://user-images.githubusercontent.com/26521388/110133157-40dda500-7dcc-11eb-86e5-726d150d3e90.gif)

Open TODOs:
* [x] Disable entries. This could be achieved by changing `Message` to `Optional<Message>`.
* [x] Toggle-able entries. This could be achieved by adding a `Entry::Toggle` or something to `Entry`.
* [x] Cool looking separators between the entries.
* [x] Bouncing on the edge of the window or else the menu is cut off.
* [ ] ~Add some internal scrollable if the list of entries is to high for the window.~ This seems to be realy hacky to implement. Nevertheless it would require for the `scrollable::State` to be hashable and maybe to fix [this](https://github.com/hecrj/iced/issues/765) first.
* [ ] Maybe a cooler default style. Some suggestions?
* [ ] Add some way of keyboard control. In common, the `Alt` + `[First character of section label]` combination is used to pop up the content of the specific section. This would require to change the `Text` label of the `Section` to a normal `String` (or `&str`)  to be able to know the first character of the label.