### PR TITLE
Update Iced to latest rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,17 +41,16 @@ default = [
 ]
 
 [dependencies]
-iced_style = { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced_style = { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-#iced = { git = "https://github.com/hecrj/iced", rev = "ea1a7248d257c7c9e4a1f3989e68b58a6bc0c4ff" }
-iced_native = { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
-iced_graphics = { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced_native = { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
+iced_graphics = { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 chrono = { version = "0.4.19", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iced_web = { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced_web = { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 dodrio = "0.2.0"
 wasm-bindgen = "0.2.69"
 

--- a/examples/badge/Cargo.toml
+++ b/examples/badge/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["badge", "colors"] }

--- a/examples/card/Cargo.toml
+++ b/examples/card/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["card", "colors"] }

--- a/examples/color_picker/Cargo.toml
+++ b/examples/color_picker/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["color_picker", "colors"] }

--- a/examples/date_picker/Cargo.toml
+++ b/examples/date_picker/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["date_picker", "colors"] }

--- a/examples/floating_button/Cargo.toml
+++ b/examples/floating_button/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["floating_button", "colors", "icons"] }

--- a/examples/modal/Cargo.toml
+++ b/examples/modal/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990", features = ["debug"] }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8", features = ["debug"] }
 iced_aw = { path = "../..", default-features = false, features = ["card", "colors", "modal"] }

--- a/examples/tab_bar/Cargo.toml
+++ b/examples/tab_bar/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", features = ["tab_bar"] }

--- a/examples/tabs/Cargo.toml
+++ b/examples/tabs/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990", features = ["image"] }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8", features = ["image"] }
 iced_aw = { path = "../..", features = ["tabs"] }

--- a/examples/tabs_min/Cargo.toml
+++ b/examples/tabs_min/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", branch = "master" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../.." }

--- a/examples/time_picker/Cargo.toml
+++ b/examples/time_picker/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 iced_aw = { path = "../..", default-features = false, features = ["colors", "time_picker"] }

--- a/examples/web/Cargo.toml
+++ b/examples/web/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
+iced =  { git = "https://github.com/hecrj/iced", rev = "a74974a8e4d8afc72c33434a22df74c3582b78a8" }
 #iced_web =  { git = "https://github.com/hecrj/iced", rev = "ea1a7248d257c7c9e4a1f3989e68b58a6bc0c4ff" }
 iced_aw = { path = "../..", default-features = false, features = ["badge", "card", "color_picker", "colors", "date_picker", "floating_button", "modal", "time_picker"] }


### PR DESCRIPTION
This PR updates the Iced dependency to the latest commit, wich should prevent a disaster.

A few week ago the dependency to `wgpu_glyp` was [updated](https://github.com/hecrj/iced/commit/5fc4210270852d8d633a63168d8a166a235236c6). At this time `wgpu_glyph` [replaced](https://github.com/hecrj/wgpu_glyph/commit/6d5a95ae0d434e851ee7fcbb088f891b9b292653) the `zerocopy` dependency with `bytemuck`.

Before that, `wgpu_glyp` had a dependency to ^0.3 zerocopy. 18 hours ago, zerocopy [published](https://crates.io/crates/zerocopy/versions) a new version 0.3.1 and had [mistakenly claimed const generics as stable](https://fuchsia.googlesource.com/fuchsia/+/df1162fe6146a1e95ba51b7649119e11ee8b10dc) - which are not. This has been noticed by the failed test at PR #4.