### PR TITLE
feat(modal): state is_shown method

### DIFF
--- a/src/native/modal.rs
+++ b/src/native/modal.rs
@@ -135,6 +135,11 @@ impl<S> State<S> {
         self.show = b;
     }
 
+    /// See if this modal will be shown or not.
+    pub const fn is_shown(&self) -> bool {
+        self.show
+    }
+
     /// Get a mutable reference to the inner state data.
     pub fn inner_mut(&mut self) -> &mut S {
         &mut self.state


### PR DESCRIPTION
Sorry for the small PR, but it seems I forgot about this while doing the other PR (i only really needed this now).

This adds a `is_shown` method to the `modal::State` to query if the modal will be shown or not.