### PR TITLE
Overwrite `overlay` method in Widget implementation for Tabs

### DIFF
--- a/src/native/tabs.rs
+++ b/src/native/tabs.rs
@@ -417,6 +417,20 @@ where
         self.width.hash(state);
         self.height.hash(state);
     }
+
+    fn overlay(
+        &mut self,
+        layout: Layout<'_>,
+    ) -> Option<iced_native::overlay::Element<'_, Message, Renderer>> {
+        let layout = match self.tab_bar_position {
+            TabBarPosition::Top => layout.children().nth(1).unwrap(),
+            TabBarPosition::Bottom => layout.children().next().unwrap(),
+        };
+        self.tabs
+            .get_mut(self.tab_bar.get_active_tab())
+            .unwrap()
+            .overlay(layout)
+    }
 }
 
 /// The renderer of a [`Tabs`](Tabs) widget.

--- a/src/native/tabs.rs
+++ b/src/native/tabs.rs
@@ -423,12 +423,18 @@ where
         layout: Layout<'_>,
     ) -> Option<iced_native::overlay::Element<'_, Message, Renderer>> {
         let layout = match self.tab_bar_position {
-            TabBarPosition::Top => layout.children().nth(1).unwrap(),
-            TabBarPosition::Bottom => layout.children().next().unwrap(),
+            TabBarPosition::Top => layout
+                .children()
+                .nth(1)
+                .expect("Native: Layout should have a tab content layout at top position"),
+            TabBarPosition::Bottom => layout
+                .children()
+                .next()
+                .expect("Native: Layout should have a tab content layout at bottom position"),
         };
         self.tabs
             .get_mut(self.tab_bar.get_active_tab())
-            .unwrap()
+            .expect("Native: self.tab_bar.get_active_tab() should never return a value greater than self.tabs.len()")
             .overlay(layout)
     }
 }


### PR DESCRIPTION
The implementation of `Widget` for `Tabs` needs to overwrite the `overlay` method, otherwise picklist cannot be used inside of tabs.