### PR TITLE
Fix README's cargo deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Every widget is hidden by a feature gate. This allows you to cherry pick the wid
 Include `iced_aw` as a dependency in your `Cargo.toml`:
 ```toml
 [dependencies]
-iced =  { git = "https://github.com/hecrj/iced", rev = "12c0c18d662d2b817b559b94c71d18e122c76990" }
-iced_aw = { git = "https://github.com/kaiden42/iced_aw", default-features = false, features = [...] }
+iced = "0.3"
+iced_aw = { git = "https://github.com/iced-rs/iced_aw", branch = "main", default-features = false, features = [...] }
 ```
 
 **Why not Crates.io?**


### PR DESCRIPTION
- Iced uses 0.3, not a git commit
- Repo is now under the `iced-rs` org
- Cargo needs to be told the repo lives in `main`, else it will try `master` and fail

Will close #13