### PR TITLE
Fix: add missing debug_assertions

### DIFF
--- a/src/native/number_input.rs
+++ b/src/native/number_input.rs
@@ -599,6 +599,7 @@ where
     }
 }
 
+#[cfg(debug_assertions)]
 impl Renderer for iced_native::renderer::Null {
     type Style = ();
 


### PR DESCRIPTION
The number-input renderer implementation for the Null renderer missed the `debug_assertion` configuration which resulted in failing release builds.

This PR fixes this.