### PR TITLE
Fix some small bugs and improve Split widget

### DIFF
--- a/src/graphics/split.rs
+++ b/src/graphics/split.rs
@@ -1,7 +1,7 @@
 //! Use a split to split the available space in two parts to display two different elements.
 //!
 //! *This API requires the following crate features to be activated: split*
-use iced_graphics::{Backend, Color, Primitive, Renderer};
+use iced_graphics::{Backend, Color, Primitive, Renderer, Vector};
 use iced_native::mouse;
 
 use crate::native::split;
@@ -125,8 +125,16 @@ where
                     background,
                     first_background,
                     second_background,
-                    first,
-                    second,
+                    Primitive::Clip {
+                        bounds: first_layout.bounds(),
+                        offset: Vector::new(0, 0),
+                        content: Box::new(first),
+                    },
+                    Primitive::Clip {
+                        bounds: second_layout.bounds(),
+                        offset: Vector::new(0, 0),
+                        content: Box::new(second),
+                    },
                     divider_background,
                 ],
             },

--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -46,9 +46,9 @@ pub struct Split<'a, Message, Renderer: self::Renderer> {
     width: Length,
     /// The height of the [`Split`](Split).
     height: Length,
-    /// TODO
+    /// The minimum size of the first element of the [`Split`](Split).
     min_size_first: u16,
-    /// TODO
+    /// The minimum size of the second element of the [`Split`](Split).
     min_size_second: u16,
     /// The message that is send when the divider of the [`Split`](Split) is moved.
     on_resize: Box<dyn Fn(u16) -> Message>,
@@ -117,6 +117,18 @@ where
     /// Sets the height of the [`Split`](Split).
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
+        self
+    }
+
+    /// Sets the minimum size of the first element of the [`Split`](Split).
+    pub fn min_size_first(mut self, size: u16) -> Self {
+        self.min_size_first = size;
+        self
+    }
+
+    /// Sets the minimum size of the second element of the [`Split`](Split).
+    pub fn min_size_second(mut self, size: u16) -> Self {
+        self.min_size_second = size;
         self
     }
 }
@@ -252,6 +264,8 @@ where
         std::any::TypeId::of::<Marker>().hash(state);
 
         self.state.divider_position.hash(state);
+        self.first.hash_layout(state);
+        self.second.hash_layout(state);
     }
 }
 


### PR DESCRIPTION
The Split widget was no hashing the layout of it's elements. In addition, the problems of the elements rendered outside the area could be solved.