### PR TITLE
Fix: overlay not shown in Split

### DIFF
--- a/src/graphics/split.rs
+++ b/src/graphics/split.rs
@@ -20,6 +20,7 @@ where
 {
     type Style = Box<dyn StyleSheet>;
 
+    #[allow(clippy::too_many_lines)]
     fn draw<Message>(
         &mut self,
         env: crate::core::renderer::DrawEnvironment<Self::Defaults, Self::Style, ()>,

--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -258,16 +258,21 @@ where
         )
     }
 
-    fn overlay(&mut self, layout: iced_native::Layout<'_>) -> Option<iced_native::overlay::Element<'_, Message, Renderer>> {
+    fn overlay(
+        &mut self,
+        layout: iced_native::Layout<'_>,
+    ) -> Option<iced_native::overlay::Element<'_, Message, Renderer>> {
         let mut children = layout.children();
-        let first_layout = children.next().expect("Native: Layout should have a first layout");
-        let _divider_layout = children.next().expect("Native: Layout should have a second layout");
-        let second_layout = children.next().expect("Native: Layout should have a second layout");
+        let first_layout = children.next()?;
+        let _divider_layout = children.next()?;
+        let second_layout = children.next()?;
 
         let first = &mut self.first;
         let second = &mut self.second;
 
-        first.overlay(first_layout).or_else(move || second.overlay(second_layout))
+        first
+            .overlay(first_layout)
+            .or_else(move || second.overlay(second_layout))
     }
 
     fn hash_layout(&self, state: &mut iced_native::Hasher) {
@@ -484,7 +489,8 @@ impl State {
     }
 
     /// Gets the position of the divider.
-    pub fn divider_position(&self) -> Option<u16> {
+    #[must_use]
+    pub const fn divider_position(&self) -> Option<u16> {
         self.divider_position
     }
 
@@ -505,6 +511,6 @@ pub enum Axis {
 
 impl Default for Axis {
     fn default() -> Self {
-        Axis::Vertical
+        Self::Vertical
     }
 }

--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -446,7 +446,7 @@ where
 }
 
 /// The state of a [`Split`](Split).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct State {
     /// The position of the divider.
     divider_position: Option<u16>,
@@ -471,6 +471,11 @@ impl State {
         }
     }
 
+    /// Gets the position of the divider.
+    pub fn divider_position(&self) -> Option<u16> {
+        self.divider_position
+    }
+
     /// Sets the position of the divider of the [`State`](State).
     pub fn set_divider_position(&mut self, position: u16) {
         self.divider_position = Some(position);
@@ -484,4 +489,10 @@ pub enum Axis {
     Horizontal,
     /// Split vertically.
     Vertical,
+}
+
+impl Default for Axis {
+    fn default() -> Self {
+        Axis::Vertical
+    }
 }

--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -258,6 +258,18 @@ where
         )
     }
 
+    fn overlay(&mut self, layout: iced_native::Layout<'_>) -> Option<iced_native::overlay::Element<'_, Message, Renderer>> {
+        let mut children = layout.children();
+        let first_layout = children.next().expect("Native: Layout should have a first layout");
+        let _divider_layout = children.next().expect("Native: Layout should have a second layout");
+        let second_layout = children.next().expect("Native: Layout should have a second layout");
+
+        let first = &mut self.first;
+        let second = &mut self.second;
+
+        first.overlay(first_layout).or_else(move || second.overlay(second_layout))
+    }
+
     fn hash_layout(&self, state: &mut iced_native::Hasher) {
         #[allow(clippy::missing_docs_in_private_items)]
         struct Marker;


### PR DESCRIPTION
This PR adds the `overlay` method implementation for the Split widget. In addition it adds a Default implementation and a method to get the current divider position to the Split's state. This should fix #31 .