### PR TITLE
Implement TabBar and Tabs for web

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ Please take a look into our examples on how to use TabBars and Tabs.
 
 Enable TabBars with the feature `tab_bar` and Tabs with `tabs`.
 
-*This widgets are currently not supporting web*
-
 ### Time Picker
 
 <center>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,20 @@ mod platform {
     pub use crate::web::{modal, modal::Modal};
 
     #[doc(no_inline)]
+    #[cfg(feature = "tab_bar")]
+    pub use crate::web::{
+        tab_bar,
+        tab_bar::{TabBar, TabLabel},
+    };
+
+    #[doc(no_inline)]
+    #[cfg(feature = "tabs")]
+    pub use crate::web::{
+        tabs,
+        tabs::{TabBarPosition, Tabs},
+    };
+
+    #[doc(no_inline)]
     #[cfg(feature = "time_picker")]
     pub use crate::web::{time_picker, time_picker::TimePicker};
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -35,6 +35,16 @@ pub mod modal;
 #[cfg(feature = "modal")]
 pub use modal::Modal;
 
+#[cfg(feature = "tab_bar")]
+pub mod tab_bar;
+#[cfg(feature = "tab_bar")]
+pub use tab_bar::{TabBar, TabLabel};
+
+#[cfg(feature = "tabs")]
+pub mod tabs;
+#[cfg(feature = "tabs")]
+pub use tabs::Tabs;
+
 #[cfg(feature = "time_picker")]
 pub mod time_picker;
 #[cfg(feature = "time_picker")]

--- a/src/web/tab_bar.rs
+++ b/src/web/tab_bar.rs
@@ -1,0 +1,351 @@
+//! Displays a [`TabBar`](TabBar) to select the content to be displayed.
+//!
+//! You have to manage the logic to show the contend by yourself or you may want
+//! to use the [`Tabs`](super::tabs::Tabs) widget instead.
+//!
+//! *This API requires the following crate features to be activated: `tab_bar`*
+use dodrio::{bumpalo, Node};
+use iced_web::{css, Bus, Css, Element, Length, Widget};
+
+pub mod tab_label;
+pub use crate::style::tab_bar::{Style, StyleSheet};
+pub use tab_label::TabLabel;
+
+use std::rc::Rc;
+
+const _DEFAULT_ICON_SIZE: u16 = 32;
+
+const DEFAULT_TEXT_SIZE: u16 = 16;
+
+const DEFAULT_CLOSE_SIZE: u16 = 16;
+
+const DEFAULT_PADDING: u16 = 5;
+
+const DEFAULT_SPACING: u16 = 0;
+
+/// A tab bar to show tabs.
+///
+/// # Example
+/// ```
+/// # use iced_aw::{TabBar, tab_bar::TabLabel};
+/// enum Message {
+///     TabSelected(usize),
+/// }
+///
+/// let active_tab = 0;
+/// let tab_bar = TabBar::new(
+///     active_tab,
+///     Message::TabSelected,   
+/// )
+/// .push(TabLabel::Text(String::from("One")))
+/// .push(TabLabel::Text(String::from("Two")))
+/// .push(TabLabel::Text(String::from("Three")));
+/// ```
+#[allow(missing_debug_implementations)]
+pub struct TabBar<Message> {
+    /// The currently active tab.
+    active_tab: usize,
+    /// The vector containing the labels of the tabs.
+    tab_labels: Vec<TabLabel>,
+    /// The function that produces the message when a tab is selected.
+    on_select: Rc<dyn Fn(usize) -> Message>,
+    /// The function that produces the message when the close icon was pressed.
+    on_close: Option<Rc<dyn Fn(usize) -> Message>>,
+    /// The width of the [`TabBar`](TabBar).
+    width: Length,
+    /// The width of the tabs of the [`TabBar`](TabBar).
+    tab_width: Length,
+    /// The width of the [`TabBar`](TabBar).
+    height: Length,
+    /// The maximum height of the [`TabBar`](TabBar).
+    max_height: u32,
+    /// The icon size.
+    text_size: u16,
+    /// The size of the close icon.
+    close_size: u16,
+    /// The padding of the tabs of the [`TabBar`](TabBar).
+    padding: u16,
+    /// The spacing of the tabs of the [`TabBar`](TabBar).
+    spacing: u16,
+    /// The style of the [`TabBar`](TabBar).
+    style: Box<dyn StyleSheet>,
+}
+
+impl<Message> TabBar<Message> {
+    /// Creates a new [`TabBar`](TabBar) with the index of the selected tab and a
+    /// specified message which will be send when a tab is selected by the user.
+    ///
+    /// It expects:
+    ///     * the index of the currently active tab.
+    ///     * the function that will be called if a tab is selected by the user.
+    ///         It takes the index of the selected tab.
+    pub fn new<F>(active_tab: usize, on_select: F) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        Self::width_tab_labels(active_tab, Vec::new(), on_select)
+    }
+
+    /// Similar to `new` but with a given Vector of the
+    /// [`TabLabel`](tab_label::TabLabel)s.Align
+    ///
+    /// It expects:
+    ///     * the index of the currently active tab.
+    ///     * a vector containing the [`TabLabel`](TabLabel)s of the [`TabBar`](TabBar).
+    ///     * the function that will be called if a tab is selected by the user.
+    ///         It takes the index of the selected tab.
+    pub fn width_tab_labels<F>(active_tab: usize, tab_labels: Vec<TabLabel>, on_select: F) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        Self {
+            active_tab,
+            tab_labels,
+            on_select: Rc::new(on_select),
+            on_close: None,
+            width: Length::Fill,
+            tab_width: Length::Fill,
+            height: Length::Shrink,
+            max_height: u32::MAX,
+            text_size: DEFAULT_TEXT_SIZE,
+            close_size: DEFAULT_CLOSE_SIZE,
+            padding: DEFAULT_PADDING,
+            spacing: DEFAULT_SPACING,
+            style: Default::default(),
+        }
+    }
+
+    /// Gets the index of the currently active tab on the [`TabBar`](TabBar).
+    pub fn get_active_tab(&self) -> usize {
+        self.active_tab
+    }
+
+    /// Sets the message that will be produced when the close icon of a tab
+    /// on the [`TabBar`](TabBar) is pressed.
+    ///
+    /// Setting this enables the drawing of a close icon on the tabs.
+    pub fn on_close<F>(mut self, on_close: F) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        self.on_close = Some(Rc::new(on_close));
+        self
+    }
+
+    /// Sets the width of the [`TabBar`](TabBar).
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Gets the width of the [`TabBar`](TabBar).
+    pub fn get_width(&self) -> Length {
+        self.width
+    }
+
+    /// Sets the width of a tab on the [`TabBar`](TabBar).
+    pub fn tab_width(mut self, width: Length) -> Self {
+        self.tab_width = width;
+        self
+    }
+
+    /// Sets the height of the [`TabBar`](TabBar).
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = height;
+        self
+    }
+
+    /// Gets the width of the [`TabBar`](TabBar).
+    pub fn get_height(&self) -> Length {
+        self.height
+    }
+
+    /// Sets the maximum height of the [`TabBar`](TabBar).
+    pub fn max_height(mut self, max_height: u32) -> Self {
+        self.max_height = max_height;
+        self
+    }
+
+    /// Sets the text size of the [`TabLabel`](tab_label::TabLabel)s of the
+    /// [`TabBar`](TabBar).
+    pub fn text_size(mut self, text_size: u16) -> Self {
+        self.text_size = text_size;
+        self
+    }
+
+    /// Sets the size of the close icon of the
+    /// [`TabLabel`](tab_label::TabLabel)s of the [`TabBar`](TabBar).
+    pub fn close_size(mut self, close_size: u16) -> Self {
+        self.close_size = close_size;
+        self
+    }
+
+    /// Sets the padding of the tabs of the [`TabBar`](TabBar).
+    pub fn padding(mut self, padding: u16) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Sets the spacing between the tabs of the [`TabBar`](TabBar).
+    pub fn spacing(mut self, spacing: u16) -> Self {
+        self.spacing = spacing;
+        self
+    }
+
+    /// Sets the style of the [`TabBar`](TabBar).
+    pub fn style(mut self, style: impl Into<Box<dyn StyleSheet>>) -> Self {
+        self.style = style.into();
+        self
+    }
+
+    /// Pushes a [`TabLabel`](tab_label::TabLabel) to the [`TabBar`](TabBar).
+    pub fn push(mut self, tab_label: TabLabel) -> Self {
+        self.tab_labels.push(tab_label);
+        self
+    }
+}
+
+impl<Message> Widget<Message> for TabBar<Message>
+where
+    Message: 'static + Clone,
+{
+    fn node<'b>(
+        &self,
+        bump: &'b bumpalo::Bump,
+        bus: &Bus<Message>,
+        style_sheet: &mut Css<'b>,
+    ) -> dodrio::Node<'b> {
+        use dodrio::builder::*;
+
+        // TODO: State-based styling
+        // (https://github.com/hecrj/iced/blob/master/web/src/widget/button.rs#L144)
+        let style = self.style.active(false);
+        let active_style = self.style.active(true);
+
+        let tabs: Vec<Node> = self.tab_labels.iter().enumerate().map(|(i, tab)| {
+            let label = match tab {
+                TabLabel::Text(t) => {
+                    use dodrio::bumpalo::collections::String;
+                    text(String::from_str_in(t, bump).into_bump_str())
+                },
+            };
+
+            let style = if self.active_tab == i {
+                active_style
+            } else {
+                style
+            };
+
+            let close = self.on_close.clone().map(|on_close| {
+                use dodrio::bumpalo::collections::String;
+                let event_bus = bus.clone();
+                div(bump)
+                    .attr(
+                        "style",
+                        bumpalo::format!(
+                            in bump,
+                            "font-size: {}px; width: auto; height: auto; \
+                            text-align: center; color: {}; cursor: pointer; \
+                            display: flex; align-items: center;",
+                            self.close_size,
+                            css::color(style.icon_color)
+                        ).into_bump_str(),
+                    )
+                    .on("click", move |_root, _vdom, _event| {
+                        event_bus.publish((on_close)(i))
+                    })
+                    .child(text(String::from_str_in(r#"×"#, bump).into_bump_str()))
+                    .finish()
+            });
+
+            let tab_label_class = style_sheet.insert(bump, css::Rule::Row);
+
+            let background = match style.tab_label_background {
+                iced_style::Background::Color(color) => css::color(color),
+            };
+
+            let mut node = div(bump)
+                .attr(
+                    "class",
+                    bumpalo::format!(in bump, "{}", tab_label_class)
+                        .into_bump_str()
+                )
+                .attr(
+                    "style",
+                    bumpalo::format!(
+                        in bump,
+                        "background: {}; border-style: solid; border-color: {}; border-width: {}px; \
+                        color: {}; padding: {}px; font-size: {}px; cursor: pointer; user-select: none; \
+                        width: {};",
+                        background,
+                        css::color(style.tab_label_border_color),
+                        style.tab_label_border_width,
+                        css::color(style.text_color),
+                        self.padding,
+                        self.text_size,
+                        css::length(self.tab_width)
+                    ).into_bump_str(),
+                ).child(label);
+
+            if let Some(close) = close {
+                node = node.child(close);
+            }
+
+            let event_bus = bus.clone();
+            let on_select = self.on_select.clone();
+            node = node.on("click", move |_root, _vdom, _event| {
+                event_bus.publish((on_select)(i));
+            });
+
+            node.finish()
+        })
+        .collect();
+
+        let tab_bar_class = style_sheet.insert(bump, css::Rule::Row);
+
+        let spacing_class = style_sheet.insert(bump, css::Rule::Spacing(self.spacing));
+
+        let background = match style.background {
+            None => String::from("none"),
+            Some(background) => match background {
+                iced_style::Background::Color(color) => css::color(color),
+            },
+        };
+
+        let node = div(bump)
+            .attr(
+                "class",
+                bumpalo::format!(in bump, "{} {}", tab_bar_class, spacing_class).into_bump_str(),
+            )
+            .attr(
+                "style",
+                bumpalo::format!(
+                    in bump,
+                    "background: {}; border-style: solid; border-color: {}; border-width: {}px; \
+                    width: {}; height: {}; maximum-height: {}px",
+                    background,
+                    style.border_color.map_or_else(
+                        || String::from("none"),
+                        |color| css::color(color),
+                    ),
+                    style.border_width,
+                    css::length(self.width),
+                    css::length(self.height),
+                    self.max_height
+                )
+                .into_bump_str(),
+            )
+            .children(tabs);
+
+        node.finish()
+    }
+}
+
+impl<'a, Message> From<TabBar<Message>> for Element<'a, Message>
+where
+    Message: 'static + Clone,
+{
+    fn from(tab_bar: TabBar<Message>) -> Self {
+        Element::new(tab_bar)
+    }
+}

--- a/src/web/tab_bar/tab_label.rs
+++ b/src/web/tab_bar/tab_label.rs
@@ -1,0 +1,12 @@
+//! A [`TabLabel`](TabLabel) showing an icon and/or a text on a tab.
+//!
+//! *This API requires the following crate features to be activated: `tab_bar`*
+
+/// A [`TabLabel`](TabLabel) showing an icon and/or a text on a tab
+/// on a [`TabBar`](super::TabBar).
+#[allow(missing_debug_implementations)]
+#[derive(Clone, Hash)]
+pub enum TabLabel {
+    /// A [`TabLabel`](TabLabel) showing only a text on the tab.
+    Text(String),
+}

--- a/src/web/tabs.rs
+++ b/src/web/tabs.rs
@@ -1,0 +1,242 @@
+//! Displays a [`Tabs`](Tabs) widget to select the content to be displayed.
+//!
+//! This is a wrapper around the [`TabBar`](super::tab_bar::TabBar) widget.
+//! Unlike the [`TabBar`](super::tab_bar::TabBar) widget it will also handle
+//! the content of the tabs.
+//!
+//! *This API requires the following crate features to be activated: tabs*
+use dodrio::bumpalo;
+use iced_web::{css, Align, Background, Bus, Css, Element, Length, Widget};
+
+pub mod tab_bar_position;
+pub use tab_bar_position::TabBarPosition;
+
+pub use crate::style::tab_bar::{Style, StyleSheet};
+use crate::{TabBar, TabLabel};
+
+/// A [`Tabs`](Tabs) widget for showing a [`TabBar`](super::tab_bar::TabBar)
+/// along with the tab's content.
+///
+/// # Example
+/// ```
+/// # use iced_aw::{TabLabel};
+/// # use iced_web::Text;
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     TabSelected(usize),
+/// }
+///
+/// let active_tab = 0;
+///
+/// let tabs = Tabs::new(
+///     active_tab,
+///     Message::TabSelected,
+/// )
+/// .push(TabLabel::Text(String::from("One")), Text::new(String::from("One")))
+/// .push(TabLabel::Text(String::from("Two")), Text::new(String::from("Two")))
+/// .push(TabLabel::Text(String::from("Three")), Text::new(String::from("Three")));
+/// ```
+///
+#[allow(missing_debug_implementations)]
+pub struct Tabs<'a, Message> {
+    tab_bar: TabBar<Message>,
+    tabs: Vec<Element<'a, Message>>,
+    tab_bar_position: TabBarPosition,
+    width: Length,
+    height: Length,
+}
+
+impl<'a, Message> Tabs<'a, Message> {
+    /// Creates a new [`Tabs`](Tabs) widget with the index of the selected tab
+    /// and a specified message which will be send when a tab is selected by
+    /// the user.
+    ///
+    /// It expects:
+    ///     * the index of the currently active tab.
+    ///     * the function that will be called if a tab is selected by the user.
+    ///         It takes the index of the selected tab.
+    pub fn new<F>(active_tab: usize, on_select: F) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        Self::with_tabs(active_tab, Vec::new(), on_select)
+    }
+
+    /// Similar to `new` but with a given Vector of the
+    /// [`TabLabel`](super::tab_bar::TabLabel) along with the tab's content.
+    ///
+    /// It expects:
+    ///     * the index of the currently active tab.
+    ///     * a vector containing the [`TabLabel`](TabLabel)s along with the content
+    ///         [`Element`](iced_native::Element)s of the [`Tabs`](Tabs).
+    ///     * the function that will be called if a tab is selected by the user.
+    ///         It takes the index of the selected tab.
+    pub fn with_tabs<F>(
+        active_tab: usize,
+        tabs: Vec<(TabLabel, Element<'a, Message>)>,
+        on_select: F,
+    ) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        let mut tab_labels = Vec::with_capacity(tabs.len());
+        let mut elements = Vec::with_capacity(tabs.len());
+
+        for (tab_label, element) in tabs {
+            tab_labels.push(tab_label);
+            elements.push(element);
+        }
+
+        Tabs {
+            tab_bar: TabBar::width_tab_labels(active_tab, tab_labels, on_select),
+            tabs: elements,
+            tab_bar_position: TabBarPosition::Top,
+            width: Length::Fill,
+            height: Length::Fill,
+        }
+    }
+
+    /// Sets the message that will be produced when the close icon of a tab
+    /// on the [`TabBar`](TabBar) is pressed.
+    ///
+    /// Setting this enables the drawing of a close icon on the tabs.
+    pub fn on_close<F>(mut self, on_close: F) -> Self
+    where
+        F: 'static + Fn(usize) -> Message,
+    {
+        self.tab_bar = self.tab_bar.on_close(on_close);
+        self
+    }
+
+    /// Sets the width of the [`Tabs`](Tabs).
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Sets the height of the [`Tabs`](Tabs).
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = height;
+        self
+    }
+
+    /// Sets the width of the [`TabBar`](super::tab_bar::TabBar) of the
+    /// [`Tabs`](Tabs).
+    pub fn tab_bar_width(mut self, width: Length) -> Self {
+        self.tab_bar = self.tab_bar.width(width);
+        self
+    }
+
+    /// Sets the height of the [`TabBar`](super::tab_bar::TabBar) of the
+    /// [`Tabs`](Tabs).
+    pub fn tab_bar_height(mut self, height: Length) -> Self {
+        self.tab_bar = self.tab_bar.height(height);
+        self
+    }
+
+    /// Sets the maximum height of the [`TabBar`](super::tab_bar::TabBar) of the
+    /// [`Tabs`](Tabs).
+    pub fn tab_bar_max_height(mut self, max_height: u32) -> Self {
+        self.tab_bar = self.tab_bar.max_height(max_height);
+        self
+    }
+
+    /// Sets the text size of the [`TabLabel`](super::tab_bar::TabLabel) of the
+    /// [`TabBar`](super::tab_bar::TabBar).
+    pub fn text_size(mut self, text_size: u16) -> Self {
+        self.tab_bar = self.tab_bar.text_size(text_size);
+        self
+    }
+
+    /// Sets the size of the close icon of the
+    /// [`TabLabel`](super::tab_bar::TabLabel) of the
+    /// [`TabBar`](super::tab_bar::TabBar).
+    pub fn close_size(mut self, close_size: u16) -> Self {
+        self.tab_bar = self.tab_bar.close_size(close_size);
+        self
+    }
+
+    /// Sets the padding of the tabs of the [`TabBar`](super::tab_bar::TabBar).
+    pub fn tab_label_padding(mut self, padding: u16) -> Self {
+        self.tab_bar = self.tab_bar.padding(padding);
+        self
+    }
+
+    /// Sets the spacing between the tabs of the
+    /// [`TabBar`](super::tab_bar::TabBar).
+    pub fn tab_label_spacing(mut self, spacing: u16) -> Self {
+        self.tab_bar = self.tab_bar.spacing(spacing);
+        self
+    }
+
+    /// Sets the style of the [`TabBar`](super::tab_bar::TabBar).
+    pub fn tab_bar_style<T>(mut self, style: T) -> Self
+    where
+        T: Into<Box<dyn StyleSheet>>,
+    {
+        self.tab_bar = self.tab_bar.style(style);
+        self
+    }
+
+    /// Sets the [`TabBarPosition`](TabBarPosition) of the
+    /// [`TabBar`](super::tab_bar::TabBar).
+    pub fn tab_bar_position(mut self, position: TabBarPosition) -> Self {
+        self.tab_bar_position = position;
+        self
+    }
+
+    /// Pushes a [`TabLabel`](super::tab_bar::TabLabel) along with the tabs
+    /// content to the [`Tabs`](Tabs).
+    pub fn push<E>(mut self, tab_label: TabLabel, element: E) -> Self
+    where
+        E: Into<Element<'a, Message>>,
+    {
+        self.tab_bar = self.tab_bar.push(tab_label);
+        self.tabs.push(element.into());
+        self
+    }
+}
+
+impl<'a, Message> Widget<Message> for Tabs<'a, Message>
+where
+    Message: 'static + Clone,
+{
+    fn node<'b>(
+        &self,
+        bump: &'b bumpalo::Bump,
+        bus: &Bus<Message>,
+        style_sheet: &mut Css<'b>,
+    ) -> dodrio::Node<'b> {
+        use dodrio::builder::*;
+
+        let tab_bar = self.tab_bar.node(bump, bus, style_sheet);
+        let content = self.tabs[self.tab_bar.get_active_tab()].node(bump, bus, style_sheet);
+
+        let node = div(bump)
+            .attr(
+                "style",
+                bumpalo::format!(
+                    in bump,
+                    "width: {}, height: {}",
+                    css::length(self.width),
+                    css::length(self.height)
+                )
+                .into_bump_str(),
+            )
+            .children(match self.tab_bar_position {
+                TabBarPosition::Top => vec![tab_bar, content],
+                TabBarPosition::Bottom => vec![content, tab_bar],
+            });
+
+        node.finish()
+    }
+}
+
+impl<'a, Message> From<Tabs<'a, Message>> for Element<'a, Message>
+where
+    Message: 'static + Clone,
+{
+    fn from(tabs: Tabs<'a, Message>) -> Self {
+        Element::new(tabs)
+    }
+}

--- a/src/web/tabs/tab_bar_position.rs
+++ b/src/web/tabs/tab_bar_position.rs
@@ -1,0 +1,18 @@
+//! A [`TabBarPosition`](TabBarPosition) for defining the position of a
+//! [`TabBar`](crate::native::tab_bar::TabBar).
+//!
+//! *This API requires the following crate features to be activated: tabs*
+
+/// A [`TabBarPosition`](TabBarPosition) for defining the position of a
+/// [`TabBar`](crate::native::tab_bar::TabBar).
+#[derive(Clone, Hash)]
+#[allow(missing_debug_implementations)]
+pub enum TabBarPosition {
+    /// A [`TabBarPosition`] for placing the
+    /// [`TabBar`](crate::native::tab_bar::TabBar) on top of its content.
+    Top,
+
+    /// A [`TabBarPosition`] for placing the
+    /// [`TabBar`](crate::native::tab_bar::TabBar) on bottom of its content.
+    Bottom,
+}


### PR DESCRIPTION
This PR adds the TabBar and Tabs widgets to the web as requested by #38 .

Known limitations:
- No icon support as there is currently no way of specifying the icon font on the web
- No hover styling as there is currently no easy way of styling on the web

@Icelk if something isn't working as expected, feel free to open up an issue. :slightly_smiling_face: 