### PR TITLE
Add missing style configuration for Split

### DIFF
--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -131,6 +131,12 @@ where
         self.min_size_second = size;
         self
     }
+
+    /// Sets the style of the [`Split`](Split).
+    pub fn style(mut self, style: impl Into<<Renderer as self::Renderer>::Style>) -> Self {
+        self.style = style.into();
+        self
+    }
 }
 
 impl<'a, Message, Renderer> Widget<Message, Renderer> for Split<'a, Message, Renderer>


### PR DESCRIPTION
This PR adds the missing associated function for setting the style of the Split widget.