### PR TITLE
Build rustdoc to github pages

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,37 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: GitHub Pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          components: rustfmt, rust-src
+      - uses: Swatinem/rust-cache@v1
+      - name: Build Documentation
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all --no-deps
+      - name: Add index.html
+        run: echo '<meta http-equiv=refresh content=0;url=iced_aw/index.html>' > target/doc/index.html
+      - name: Deploy Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./target/doc


### PR DESCRIPTION
This crate is not available on crates.io, so you can not read its docs on docs.rs.

I have a similar crate that can not be published to crates.io, so I just use GitHub pages for hosting the docs and linking to it from the readme:

https://github.com/Luro02/array-map/tree/gh-pages

and this is the link to the docs: https://luro02.github.io/array-map/

I think this would be nice to have for this crate, so I created this PR.

---

I don't know if you want to use a real domain name, which you can do by going to the settings of the repository under GitHub pages there is a field to add a custom domain and then adding this to the yaml:

```diff,yml
          publish_branch: gh-pages
          publish_dir: ./target/doc
+         cname: iced_aw.iced.rs
```

Otherwise, one could access the docs through this url: https://iced-rs.github.io/iced_aw/