### PR TITLE
Removed no longer needed <S> from style functions

### DIFF
--- a/src/native/color_picker.rs
+++ b/src/native/color_picker.rs
@@ -89,7 +89,7 @@ where
     }
 
     /// Sets the style of the [`ColorPicker`](ColorPicker).
-    pub fn style<S>(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
+    pub fn style(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style_sheet = style_sheet.into();
         self
     }

--- a/src/native/date_picker.rs
+++ b/src/native/date_picker.rs
@@ -84,7 +84,7 @@ impl<'a, Message: Clone, Renderer: iced_native::Renderer> DatePicker<'a, Message
     }
 
     /// Sets the style of the [`DatePicker`](DatePicker).
-    pub fn style<S>(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
+    pub fn style(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style_sheet = style_sheet.into();
         //self.button_style = style.into();
         self

--- a/src/native/time_picker.rs
+++ b/src/native/time_picker.rs
@@ -105,7 +105,7 @@ where
     }
 
     /// Sets the style of the [`TimePicker`](TimePicker).
-    pub fn style<S>(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
+    pub fn style(mut self, style_sheet: impl Into<Box<dyn StyleSheet>>) -> Self {
         self.style_sheet = style_sheet.into();
         self
     }


### PR DESCRIPTION
This is to fix the style functions in a few widgets. The error occurs as there is no longer a use for `<S>` so `<S>` is no longer preset by the compiler hence you must manually set it even though it does nothing now.