### PR TITLE
Show which item is selected in `SelectionList`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 Cargo.lock
 pkg/
 .vscode
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,12 @@ default = [
 ]
 
 [dependencies]
-iced_style = { git = "https://github.com/hecrj/iced.git", rev = "adce9e0" }
+iced_style = { git = "https://github.com/iced-rs/iced.git", rev = "adce9e0" }
 num-traits = { version = "0.2.14", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-iced_native = { git = "https://github.com/hecrj/iced.git", rev = "adce9e0" }
-iced_graphics = { git = "https://github.com/hecrj/iced.git", rev = "adce9e0" }
+iced_native = { git = "https://github.com/iced-rs/iced.git", rev = "adce9e0" }
+iced_graphics = { git = "https://github.com/iced-rs/iced.git", rev = "adce9e0" }
 chrono = { version = "0.4.19", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 

--- a/src/native/selection_list.rs
+++ b/src/native/selection_list.rs
@@ -77,6 +77,10 @@ where
             .iter()
             .position(|option| Some(option) == selected.as_ref());
 
+        let last_selected_index = options
+            .iter()
+            .position(|option| Some(option) == selected.as_ref());
+
         let container = Container::new(Scrollable::new(&mut state.scrollable).push(List {
             options,
             hovered_option,

--- a/src/native/selection_list.rs
+++ b/src/native/selection_list.rs
@@ -84,7 +84,8 @@ where
         let container = Container::new(Scrollable::new(&mut state.scrollable).push(List {
             options,
             hovered_option,
-            last_selection,
+            last_selected_item: last_selection,
+            last_selected_index,
             font: iced_graphics::Font::default(),
             style,
             on_selected: Box::new(on_selected),

--- a/src/native/selection_list/list.rs
+++ b/src/native/selection_list/list.rs
@@ -6,7 +6,7 @@ use iced_native::{
     event,
     layout::{Limits, Node},
     mouse, renderer, touch, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle,
-    Shell, Size, Widget,
+    Renderer, Shell, Size, Widget,
 };
 use std::marker::PhantomData;
 

--- a/src/style/selection_list.rs
+++ b/src/style/selection_list.rs
@@ -18,6 +18,10 @@ pub struct Style {
     /// The container Border color
     pub border_color: Color,
     /// The List Label Text Select Color
+    pub hovered_text_color: Color,
+    /// The List Label Text Select Background Color
+    pub hovered_background: Background,
+    /// The List Label Text Select Color
     pub selected_text_color: Color,
     /// The List Label Text Select Background Color
     pub selected_background: Background,
@@ -38,8 +42,10 @@ impl std::default::Default for Style {
             background: Background::Color([0.87, 0.87, 0.87].into()),
             border_width: 1.0,
             border_color: [0.7, 0.7, 0.7].into(),
+            hovered_text_color: Color::WHITE,
+            hovered_background: Background::Color([0.4, 0.4, 1.0].into()),
             selected_text_color: Color::WHITE,
-            selected_background: Background::Color([0.4, 0.4, 1.0].into()),
+            selected_background: Background::Color([0.0, 1.0, 0.0].into()),
             width: Length::Fill,
             height: Length::Fill,
             padding: 5,


### PR DESCRIPTION
This PR implements an easy way to tell which item in a `SelectionList` is currently selected by tracking the index of the currently selected item and styling it accordingly.

Previously, `Style.selected_text_color` and `Style.selected_background` defined the styling of the item that the mouse was hovering over. These have been renamed to `Style.hovered_text_color` and `Style.hovered_background`, respectively, and `Style.selected_text_color` and `Style.selected_background` now accurately refer to the styling applied to the currently **selected** item.

I have verified that the `selection_list` example still works - no code changes were required.