### PR TITLE
feat: make the floating button round

### DIFF
--- a/examples/floating_element/src/main.rs
+++ b/examples/floating_element/src/main.rs
@@ -1,7 +1,9 @@
+use iced::widget::button;
+use iced::widget::button::Appearance;
 use iced::{
     theme,
     widget::{Button, Column, Container, Scrollable, Text},
-    Element, Length, Sandbox, Settings,
+    Element, Length, Sandbox, Settings, Theme,
 };
 
 use iced_aw::floating_element::{self, FloatingElement};
@@ -65,7 +67,9 @@ impl Sandbox for FloatingElementExample {
                 //.style(iced_aw::style::button::Primary),
                 .on_press(Message::ButtonPressed)
                 .padding(5)
-                .style(theme::Button::Primary)
+                .style(theme::Button::Custom(Box::new(CircleButtonStyle::new(
+                    theme::Button::Primary,
+                ))))
                 .into()
             },
         )
@@ -80,5 +84,26 @@ impl Sandbox for FloatingElementExample {
             .center_x()
             .center_y()
             .into()
+    }
+}
+
+struct CircleButtonStyle {
+    theme: theme::Button,
+}
+
+impl CircleButtonStyle {
+    pub fn new(theme: theme::Button) -> Self {
+        Self { theme }
+    }
+}
+
+impl button::StyleSheet for CircleButtonStyle {
+    type Style = Theme;
+
+    fn active(&self, style: &Self::Style) -> Appearance {
+        let mut appearance = style.active(&self.theme);
+        appearance.border_radius = 200.0;
+
+        appearance
     }
 }


### PR DESCRIPTION
by apply the custom button style with 200.0 radius, the button now looks like a round and similar to the example gif

the gif round is 
![image](https://user-images.githubusercontent.com/10096425/201709129-1bad136d-cfe1-41c9-8079-1c4077a10f73.png)
and the round created by PR
![image](https://user-images.githubusercontent.com/10096425/201709223-587e73f3-a321-4a66-a586-8f9f8a38fd0b.png)