### PR TITLE
Upgrade to iced 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,17 +60,17 @@ lazy_static = { version = "1.4.0", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.iced_native]
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "8221794"
-version = "0.7"
+version = "0.8"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.iced_graphics]
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "8221794"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies.iced_style]
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "8221794"
-version = "0.5.0"
+version = "0.6.0"
 
 [profile.dev.package."*"]
 opt-level = 2
@@ -96,7 +96,7 @@ members = [
 [workspace.dependencies.iced]
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "8221794"
-version = "0.6.0"
+version = "0.7.0"
 
 [workspace.dependencies.iced_aw]
 path = "./"

--- a/src/native/number_input.rs
+++ b/src/native/number_input.rs
@@ -328,7 +328,13 @@ where
         Node::with_children(size, vec![content, modifier])
     }
 
-    fn operate(&self, tree: &mut Tree, layout: Layout<'_>, operation: &mut dyn Operation<Message>) {
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<Message>,
+    ) {
         operation.container(None, &mut |operation| {
             self.content.operate(
                 &mut tree.children[0],
@@ -336,6 +342,7 @@ where
                     .children()
                     .next()
                     .expect("NumberInput inner child Textbox was not created."),
+                renderer,
                 operation,
             );
         });

--- a/src/native/tabs.rs
+++ b/src/native/tabs.rs
@@ -526,15 +526,22 @@ where
         })
     }
 
-    fn operate(&self, tree: &mut Tree, layout: Layout<'_>, operation: &mut dyn Operation<Message>) {
+    fn operate(
+        &self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation<Message>,
+    ) {
         let active_tab = self.tab_bar.get_active_tab();
         operation.container(None, &mut |operation| {
             self.tabs[active_tab].as_widget().operate(
                 &mut tree.children[active_tab],
                 layout.children().nth(1).expect("TabBar is 0th child, contents are 1st node"),
+                renderer,
                 operation,
             );
-        })
+        });
     }
 }
 


### PR DESCRIPTION
Only minor changes are needed to compile against `iced` 0.7.
I have tested all the programs in examples/ and they all compile, run and seem to work.
Updated `iced_native` to 0.8, `iced_graphics` to 0.6, `iced_style` to 0.6, `iced` to 0.7.

Examples `time_picker` and `date_picker` give deprecation warnings for `chrono`, but that is unrelated to the changes made.
There's some `cargo fmt` changes that should probably be done too, but I only applied formatting to code I changed in this PR.
