### PR TITLE
Fix doctests by using the native type version

### DIFF
--- a/src/native/badge.rs
+++ b/src/native/badge.rs
@@ -17,10 +17,10 @@ const BORDER_RADIUS_RATIO: f32 = 34.0 / 15.0;
 ///
 /// # Example
 /// ```
-/// # use iced_aw::style::badge;
 /// # use iced_native::{widget::Text, renderer::Null};
+/// # use iced_aw::native::badge;
 /// #
-/// # pub type Badge<'a, Message> = iced_aw::Badge<'a, Message, Null>;
+/// # pub type Badge<'a, Message> = badge::Badge<'a, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 /// }

--- a/src/native/card.rs
+++ b/src/native/card.rs
@@ -3,8 +3,10 @@
 //! *This API requires the following crate features to be activated: card*
 use iced_native::{
     alignment::{Horizontal, Vertical},
-    event, mouse, renderer::{self, BorderRadius}, touch, Alignment, Clipboard, Color, Event, Layout, Length, Padding,
-    Point, Rectangle, Shell, Size,
+    event, mouse,
+    renderer::{self, BorderRadius},
+    touch, Alignment, Clipboard, Color, Event, Layout, Length, Padding, Point, Rectangle, Shell,
+    Size,
 };
 use iced_native::{widget::Tree, Element, Widget};
 
@@ -20,8 +22,9 @@ const DEFAULT_PADDING: f32 = 10.0;
 /// ```
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::Text;
+/// # use iced_aw::native::card;
 /// #
-/// # pub type Card<'a, Message> = iced_aw::Card<'a, Message, Null>;
+/// # pub type Card<'a, Message> = card::Card<'a, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     ClosingCard,

--- a/src/native/floating_element.rs
+++ b/src/native/floating_element.rs
@@ -20,8 +20,9 @@ use super::overlay::floating_element::FloatingElementOverlay;
 /// ```
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::{button, Button, Column, Text};
+/// # use iced_aw::native::floating_element;
 /// #
-/// # pub type FloatingElement<'a, B, Message> = iced_aw::FloatingElement<'a, B, Message, Null>;
+/// # pub type FloatingElement<'a, B, Message> = floating_element::FloatingElement<'a, B, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     ButtonPressed,

--- a/src/native/grid.rs
+++ b/src/native/grid.rs
@@ -13,8 +13,9 @@ use iced_native::{overlay, widget::Tree, Element, Widget};
 /// ```
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::Text;
+/// # use iced_aw::native::grid;
 /// #
-/// # pub type Grid<'a, Message> = iced_aw::Grid<'a, Message, Null>;
+/// # pub type Grid<'a, Message> = grid::Grid<'a, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 /// }

--- a/src/native/modal.rs
+++ b/src/native/modal.rs
@@ -15,12 +15,12 @@ pub use crate::style::modal::StyleSheet;
 ///
 /// # Example
 /// ```
-/// # use iced_aw::modal;
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::Text;
+/// # use iced_aw::native::modal;
 /// #
 /// # pub type Modal<'a, Content, Message>
-/// #  = iced_aw::Modal<'a, Message, Content, Null>;
+/// #  = modal::Modal<'a, Message, Content, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     CloseModal,

--- a/src/native/number_input.rs
+++ b/src/native/number_input.rs
@@ -32,7 +32,7 @@ const DEFAULT_PADDING: u16 = 5;
 /// # Example
 /// ```
 /// # use iced_native::renderer::Null;
-/// # use iced_aw::number_input;
+/// # use iced_aw::native::number_input;
 /// #
 /// # pub type NumberInput<'a, T, Message> = number_input::NumberInput<'a, T, Message, Null>;
 /// #[derive(Debug, Clone)]

--- a/src/native/split.rs
+++ b/src/native/split.rs
@@ -22,8 +22,9 @@ pub use crate::style::split::{Appearance, StyleSheet};
 /// # use iced_aw::split::{State, Axis};
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::Text;
+/// # use iced_aw::native::split;
 /// #
-/// # pub type Split<'a, Message> = iced_aw::Split<'a, Message, Null>;
+/// # pub type Split<'a, Message> = split::Split<'a, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     Resized(u16),

--- a/src/native/tab_bar.rs
+++ b/src/native/tab_bar.rs
@@ -39,8 +39,9 @@ const DEFAULT_SPACING: u16 = 0;
 /// ```
 /// # use iced_aw::{TabLabel};
 /// # use iced_native::{renderer::Null};
+/// # use iced_aw::native::tab_bar;
 /// #
-/// # pub type TabBar<Message> = iced_aw::TabBar<Message, Null>;
+/// # pub type TabBar<Message> = tab_bar::TabBar<Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     TabSelected(usize),

--- a/src/native/tabs.rs
+++ b/src/native/tabs.rs
@@ -11,7 +11,7 @@ use iced_native::{
     mouse, Clipboard, Event, Font, Layout, Length, Point, Rectangle, Shell, Size,
 };
 use iced_native::{
-    widget::{Row, Tree, Operation},
+    widget::{Operation, Row, Tree},
     Element, Widget,
 };
 
@@ -28,8 +28,9 @@ pub use tab_bar_position::TabBarPosition;
 /// # use iced_aw::{TabLabel};
 /// # use iced_native::renderer::Null;
 /// # use iced_native::widget::Text;
+/// # use iced_aw::native::tabs;
 /// #
-/// # pub type Tabs<'a, Message> = iced_aw::Tabs<'a, Message, Null>;
+/// # pub type Tabs<'a, Message> = tabs::Tabs<'a, Message, Null>;
 /// #[derive(Debug, Clone)]
 /// enum Message {
 ///     TabSelected(usize),
@@ -537,7 +538,10 @@ where
         operation.container(None, &mut |operation| {
             self.tabs[active_tab].as_widget().operate(
                 &mut tree.children[active_tab],
-                layout.children().nth(1).expect("TabBar is 0th child, contents are 1st node"),
+                layout
+                    .children()
+                    .nth(1)
+                    .expect("TabBar is 0th child, contents are 1st node"),
                 renderer,
                 operation,
             );


### PR DESCRIPTION
Doctests seems to have been broken for at least a few commits. I noticed it before I started the 0.7 PR but decided not to change it in the 0.7 PR, as it did not bring any new errors.

The problem is that `Theme` has been added, and I couldn't figure out how to make `Null` take a theme easily. It was a much smaller change to simply use the native type in the doctests for the native elements. It shouldn't matter which type we import as the imports are hidden in the documentation anyway and are just used to make the doctests run successfully. It also makes a ton of sense to use the native type in the native files.

With this PR, `cargo test` will be successful again.

I also ran `cargo fmt` on the files I changed. But there are still other files which have not been changed in this PR which will fail the `cargo fmt` test.