### PR TITLE
Another menu widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ members = [
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "8221794"
 version = "0.7.0"
+features = ["svg"]
 
 [workspace.dependencies.iced_aw]
 path = "./"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ wrap = []
 number_input = ["num-traits"]
 selection_list = []
 split = []
+menu = []
+quad = []
 
 default = [
     "badge",
@@ -46,6 +48,8 @@ default = [
     "wrap",
     "selection_list",
     "split",
+    "menu",
+    "quad",
 ]
 
 [dependencies]
@@ -89,6 +93,7 @@ members = [
     "examples/number_input",
     "examples/selection_list",
     "examples/split",
+    "examples/menu"
 ]
 
 [workspace.dependencies.iced]

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 iced_aw = { workspace = true, features = [
     "menu",
     "quad",
+    "icon_text"
 ] }
 iced.workspace = true

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "menu"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+iced_aw = { workspace = true, features = [
+    "menu",
+    "quad",
+] }
+iced.workspace = true

--- a/examples/menu/caret-right-fill.svg
+++ b/examples/menu/caret-right-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-fill" viewBox="0 0 16 16">
+  <path d="m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z"/>
+</svg>

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -1,4 +1,4 @@
-use iced::widget::{ slider, checkbox, container, button, text,text_input, row, toggler, horizontal_space};
+use iced::widget::{ slider, checkbox, container, button, text,text_input, row, toggler, horizontal_space, svg};
 use iced::widget::column as col;
 use iced::{Application, Length, Color, alignment, theme, Element,};
 
@@ -258,8 +258,9 @@ fn debug_item<'a>(
 }
 
 fn color_item<'a>(
-    color: Color,
+    color: impl Into<Color>,
 ) -> MenuTree<'a, Message, iced::Renderer>{
+    let color = color.into();
     MenuTree::new(
         base_button(
             circle(color),
@@ -275,6 +276,18 @@ fn sub_menu<'a>(
     msg: Message, 
     children: Vec<MenuTree<'a, Message, iced::Renderer>>
 ) -> MenuTree<'a, Message, iced::Renderer>{
+    let handle = svg::Handle::from_path(format!(
+        "{}/caret-right-fill.svg",
+        env!("CARGO_MANIFEST_DIR")
+    ));
+    let arrow = svg(handle)
+    .width(Length::Shrink)
+    .style(theme::Svg::custom_fn(|theme|{
+        svg::Appearance{
+            color: Some(theme.extended_palette().background.base.text),
+        }
+    }));
+    
     MenuTree::with_children(
         base_button(
             row![
@@ -282,10 +295,7 @@ fn sub_menu<'a>(
                     .width(Length::Fill)
                     .height(Length::Fill)
                     .vertical_alignment(alignment::Vertical::Center), 
-                text(" > ")
-                    .size(20)
-                    .height(Length::Fill)
-                    .vertical_alignment(alignment::Vertical::Center), 
+                arrow
             ],
             msg
         )
@@ -474,7 +484,6 @@ fn menu_2<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
         slider(0..=255, app.value, Message::ValueChange)
     ]);
 
-    // let tx = MenuTree::new(text("Text"));
     let txn = MenuTree::new(text_input("", &app.text, Message::TextChange));
     
     let root = MenuTree::with_children(
@@ -526,10 +535,10 @@ fn menu_3<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
                     toggler(Some("Dark Mode".into()), app.dark_mode, Message::ThemeChange)
                 ].padding([0, 8])
             ),
-            color_item(Color::from([0.45, 0.25, 0.57])),
-            color_item(Color::from([0.15, 0.59, 0.64])),
-            color_item(Color::from([0.76, 0.82, 0.20])),
-            color_item(Color::from([0.17, 0.27, 0.33])),
+            color_item([0.45, 0.25, 0.57]),
+            color_item([0.15, 0.59, 0.64]),
+            color_item([0.76, 0.82, 0.20]),
+            color_item([0.17, 0.27, 0.33]),
             primary,
         ]
     );

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -1,0 +1,538 @@
+use iced::widget::{ slider, checkbox, container, button, text,text_input, row, toggler, horizontal_space};
+use iced::widget::column as col;
+use iced::{Application, Length, Color, alignment, theme, Element,};
+
+use iced_aw::menu::{MenuBar, MenuTree, PathHighlight};
+use iced_aw::quad;
+
+pub fn main() -> iced::Result{
+    App::run(iced::Settings{
+        default_text_size: 15,
+        window: iced::window::Settings{
+            size: (800, 500),
+            // position: iced::window::Position::Default,
+            ..Default::default()
+        },
+        ..Default::default()
+    })
+}
+
+#[derive(Debug, Clone)]
+enum Message{
+    None,
+    Debug(String),
+    ValueChange(u8),
+    CheckChange(bool),
+    ToggleChange(bool),
+    ColorChange(Color),
+    Flip,
+    ThemeChange(bool),
+    TextChange(String),
+}
+
+struct App{
+    title: String,
+    value: u8,
+    check: bool,
+    toggle: bool,
+    theme: iced::Theme,
+    flip: bool,
+    dark_mode: bool,
+    text: String,
+}
+impl Application for App{
+    type Executor = iced::executor::Default;
+    type Message = Message;
+    type Theme = iced::Theme;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, iced::Command<Self::Message>) {
+        let theme = iced::Theme::custom(theme::Palette{
+            primary: Color::from([0.45, 0.25, 0.57]),
+            ..iced::Theme::Light.palette()
+        });
+        /*
+        [0.45, 0.25, 0.57]
+        */
+
+        (
+            Self{
+                title: "Menu Test".to_string(),
+                value: 0,
+                check: false,
+                toggle: false,
+                theme,
+                flip: false,
+                dark_mode:false,
+                text: "Text Input".into()
+            },
+            iced::Command::none()
+        )
+    }
+
+    fn theme(&self) -> Self::Theme {
+        self.theme.clone()
+    }
+
+    fn title(&self) -> String {
+        self.title.clone()
+    }
+
+    fn update(&mut self, message: Self::Message) -> iced::Command<Self::Message> {
+        match message{
+            Message::Debug(s) => {
+                self.title = s.clone();
+            },
+            Message::ValueChange(v) => {
+                self.value = v;
+                self.title = v.to_string();
+            },
+            Message::CheckChange(c) => {
+                self.check = c;
+                self.title = c.to_string();
+            }
+            Message::ToggleChange(t) => {
+                self.toggle = t;
+                self.title = t.to_string();
+            }
+            Message::ColorChange(c) => {
+                self.theme = iced::Theme::custom(theme::Palette{
+                    primary: c,
+                    ..self.theme.palette()
+                });
+                self.title = format!("[{:.2}, {:.2}, {:.2}]", c.r, c.g, c.b);
+                
+            },
+            Message::Flip => self.flip = !self.flip,
+            Message::ThemeChange(b) => {
+                self.dark_mode = b;
+                let primary = self.theme.palette().primary;
+                if b {
+                    self.theme = iced::Theme::custom(theme::Palette{
+                        primary,
+                        ..iced::Theme::Dark.palette()
+                    })
+                }else{
+                    self.theme = iced::Theme::custom(theme::Palette{
+                        primary,
+                        ..iced::Theme::Light.palette()
+                    })
+                }
+            },
+            Message::TextChange(s) => {
+                self.text = s.clone();
+                self.title = s;
+            }
+            _ => ()
+        }
+        iced::Command::none()
+    }
+
+    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+        
+        let mb = MenuBar::new(vec![
+            menu_1(self),
+            menu_2(self),
+            menu_3(self),
+        ])
+            .spacing(4)
+            .item_size([180.0, 25.0])
+            .bounds_expand(30)
+            .path_highlight(Some(PathHighlight::MenuActive))
+            ;
+        
+        let r = row!(
+            horizontal_space(Length::Units(8)),
+            mb,
+        ).padding([2,0]);
+
+        let top_bar_style:fn(&iced::Theme)->container::Appearance = |_theme|{
+            container::Appearance{
+                // background: Some(Color::from([0.8;3]).into()),
+                background: Some(Color::TRANSPARENT.into()),
+                ..Default::default()
+            }
+        };
+        let top_bar = container(r)
+            .width(Length::Fill)
+            .style(top_bar_style)
+            ;
+
+        let back_style:fn(&iced::Theme)->container::Appearance = |theme|{
+            container::Appearance{
+                background: Some(theme.extended_palette().primary.base.color.into()),
+                ..Default::default()
+            }
+        };
+        let back = container(col![])
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(back_style)
+            ;
+
+        let c = if self.flip{
+            col![
+                back,
+                top_bar,
+            ]
+        }else{
+            col![
+                top_bar,
+                back,
+            ]
+        };
+
+        c.into()
+    }
+}
+
+
+struct ButtonStyle;
+    impl button::StyleSheet for ButtonStyle{
+        type Style = iced::Theme;
+
+        fn active(&self, style: &Self::Style) -> button::Appearance {
+            button::Appearance{
+                // text_color: Color::BLACK,
+                text_color: style.extended_palette().background.base.text,
+                border_radius: 4.0.into(),
+                background: Some(Color::TRANSPARENT.into()),
+                // background: Some(Color::from_rgba(0.0, 0.0, 0.0, 0.2).into()),
+                ..Default::default()
+            }
+        }
+
+        fn hovered(&self, style: &Self::Style) -> button::Appearance {
+            let plt = style.extended_palette();
+            
+            button::Appearance{
+                // background: Some(Color::from_rgba(0.0, 0.0, 0.0, 0.8).into()),
+                // background: Some(Color::TRANSPARENT.into()),
+                // border_radius: 4.0.into(),
+                background: Some(plt.primary.weak.color.into()),
+                text_color: plt.primary.weak.text,
+                ..self.active(style)
+            }
+        }
+    }
+
+
+
+fn base_button<'a>(
+    content: impl Into<Element<'a, Message, iced::Renderer>>, 
+    msg: Message
+) -> button::Button<'a, Message, iced::Renderer>{
+    button(content)
+        .padding([4, 8])
+        .style(iced::theme::Button::Custom(Box::new(ButtonStyle{})))
+        .on_press(msg)
+}
+
+fn labeled_button<'a>(
+    label: &str,
+    msg: Message
+) -> button::Button<'a, Message, iced::Renderer>{
+    base_button(
+        text(label)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .vertical_alignment(alignment::Vertical::Center),
+        msg
+    )
+}
+
+fn debug_button<'a>(
+    label: &str,
+) -> button::Button<'a, Message, iced::Renderer>{
+    labeled_button(label, Message::Debug(label.into()))
+}
+
+fn debug_item<'a>(
+    label: &str,
+) -> MenuTree<'a, Message, iced::Renderer>{
+    MenuTree::new(
+        debug_button(label)
+            .width(Length::Fill)
+            .height(Length::Fill)
+    )
+}
+
+fn color_item<'a>(
+    color: Color,
+) -> MenuTree<'a, Message, iced::Renderer>{
+    MenuTree::new(
+        base_button(
+            circle(color),
+            Message::ColorChange(color),
+        )
+    )
+}
+
+
+
+fn sub_menu<'a>(
+    label: &str, 
+    msg: Message, 
+    children: Vec<MenuTree<'a, Message, iced::Renderer>>
+) -> MenuTree<'a, Message, iced::Renderer>{
+    MenuTree::with_children(
+        base_button(
+            row![
+                text(label)
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .vertical_alignment(alignment::Vertical::Center), 
+                text(" > ")
+                    .size(20)
+                    .height(Length::Fill)
+                    .vertical_alignment(alignment::Vertical::Center), 
+            ],
+            msg
+        )
+        .width(Length::Fill)
+        .height(Length::Fill),
+        children
+    )
+}
+
+fn debug_sub_menu<'a>(
+    label: &str, 
+    children: Vec<MenuTree<'a, Message, iced::Renderer>>
+) -> MenuTree<'a, Message, iced::Renderer>{
+    sub_menu(label, Message::Debug(label.into()), children)
+}
+
+
+fn separator<'a>() -> MenuTree<'a, Message, iced::Renderer>{
+    MenuTree::new(quad::Quad{
+        color: [0.5;3].into(),
+        border_radius: 4.0.into(),
+        inner_bounds: quad::InnerBounds::Ratio(0.98, 0.1),
+        ..Default::default()
+    })
+}
+
+fn dot_separator<'a>() -> MenuTree<'a, Message, iced::Renderer>{
+    MenuTree::new(
+        text("·························")
+            .size(30)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .horizontal_alignment(alignment::Horizontal::Center)
+            .vertical_alignment(alignment::Vertical::Center)
+    )
+}
+
+fn labeled_separator<'a>(label:&'a str) -> MenuTree<'a, Message, iced::Renderer>{
+    let q_1 = quad::Quad{
+        color: [0.5;3].into(),
+        border_radius: 4.0.into(),
+        inner_bounds: quad::InnerBounds::Ratio(0.98, 0.1),
+        ..Default::default()
+    };
+    let q_2 = quad::Quad{
+        color: [0.5;3].into(),
+        border_radius: 4.0.into(),
+        inner_bounds: quad::InnerBounds::Ratio(0.98, 0.1),
+        ..Default::default()
+    };
+
+    MenuTree::new(
+        row![
+            q_1,
+            text(label)
+                .height(Length::Fill)
+                .vertical_alignment(alignment::Vertical::Center),
+            q_2,
+        ]
+    )
+}
+
+fn circle<'a>(color: Color) -> quad::Quad{
+    let radius = 10.0;
+    
+    quad::Quad{
+        color,
+        inner_bounds: quad::InnerBounds::Square(radius * 2.0),
+        border_radius: radius.into(),
+        ..Default::default()
+    }
+}
+
+
+
+fn menu_1<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
+    
+    let sub_5 = debug_sub_menu(
+        "SUB",
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            
+        ]
+    );
+    let sub_4 = debug_sub_menu(
+        "SUB",
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            
+        ]
+    );
+    let sub_3 = debug_sub_menu(
+        "More sub menus",
+        vec![
+            debug_item("You can"),
+            debug_item("nest menus"),
+            sub_4,
+            debug_item("how ever"),
+            debug_item("You like"),
+            sub_5,
+        ]
+    );
+    let sub_2 = debug_sub_menu(
+        "Another sub menu",
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            sub_3,
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+        ]
+    );
+    let sub_1 = debug_sub_menu(
+        "A sub menu",
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            sub_2,
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+        ]
+    );
+
+    let root = MenuTree::with_children(
+        debug_button("Nested Menus"),
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            sub_1,
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+        ]
+    );
+
+    root
+}
+
+fn menu_2<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
+
+    let sub_1 = MenuTree::with_children(
+        container(
+            toggler(Some("Or as a sub menu item".to_string()), app.toggle, Message::ToggleChange)
+        ).padding([0,8])
+        .height(Length::Fill)
+        .align_y(alignment::Vertical::Center),
+        vec![
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+            debug_item("Item"),
+        ]
+    );
+
+    let bt = MenuTree::new(
+        button(
+            text("Button")
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .vertical_alignment(alignment::Vertical::Center)
+        )
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .on_press(Message::Debug("Button".into()))
+            
+    );
+
+    let cb = MenuTree::new(
+        checkbox("Checkbox", app.check, Message::CheckChange)
+            .width(Length::Fill)
+    );
+
+    let sld = MenuTree::new(row![
+        "Slider",
+        horizontal_space(Length::Units(8)),
+        slider(0..=255, app.value, Message::ValueChange)
+    ]);
+
+    // let tx = MenuTree::new(text("Text"));
+    let txn = MenuTree::new(text_input("", &app.text, Message::TextChange));
+    
+    let root = MenuTree::with_children(
+        debug_button("Widgets"),
+        vec![
+            debug_item("You can use any widget"),
+            debug_item("as a menu item"),
+            bt,
+            cb,
+            sld,
+            txn,
+            sub_1,
+            separator(),
+            debug_item("Seperators are also widgets"),
+            labeled_separator("Separator"),
+            debug_item("Item"),
+            debug_item("Item"),
+            dot_separator(),
+            debug_item("Item"),
+            debug_item("Item"),
+        ]
+    );
+
+    root
+}
+
+fn menu_3<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
+    let [r,g,b,_] = app.theme.palette().primary.into_rgba8();
+    
+    let primary = debug_sub_menu(
+        "Primary",
+        vec![
+            MenuTree::new(slider(0..=255, r, move |x| Message::ColorChange( Color::from_rgb8(x, g, b) ) )),
+            MenuTree::new(slider(0..=255, g, move |x| Message::ColorChange( Color::from_rgb8(r, x, b) ) )),
+            MenuTree::new(slider(0..=255, b, move |x| Message::ColorChange( Color::from_rgb8(r, g, x) ) )),
+        ]
+    );
+
+    let root = MenuTree::with_children(
+        labeled_button("Controls", Message::Debug("Click Me".into())),
+        vec![
+            MenuTree::new(
+                labeled_button("Flip", Message::Flip)
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+            ),
+            MenuTree::new(
+                row![
+                    toggler(Some("Dark Mode".into()), app.dark_mode, Message::ThemeChange)
+                ].padding([0, 8])
+            ),
+            color_item(Color::from([0.45, 0.25, 0.57])),
+            color_item(Color::from([0.15, 0.59, 0.64])),
+            color_item(Color::from([0.76, 0.82, 0.20])),
+            color_item(Color::from([0.17, 0.27, 0.33])),
+            primary,
+        ]
+    );
+
+    root
+}

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -51,9 +51,6 @@ impl Application for App{
             primary: Color::from([0.45, 0.25, 0.57]),
             ..iced::Theme::Light.palette()
         });
-        /*
-        [0.45, 0.25, 0.57]
-        */
 
         (
             Self{
@@ -148,7 +145,6 @@ impl Application for App{
 
         let top_bar_style:fn(&iced::Theme)->container::Appearance = |_theme|{
             container::Appearance{
-                // background: Some(Color::from([0.8;3]).into()),
                 background: Some(Color::TRANSPARENT.into()),
                 ..Default::default()
             }
@@ -193,11 +189,9 @@ struct ButtonStyle;
 
         fn active(&self, style: &Self::Style) -> button::Appearance {
             button::Appearance{
-                // text_color: Color::BLACK,
                 text_color: style.extended_palette().background.base.text,
                 border_radius: 4.0.into(),
                 background: Some(Color::TRANSPARENT.into()),
-                // background: Some(Color::from_rgba(0.0, 0.0, 0.0, 0.2).into()),
                 ..Default::default()
             }
         }
@@ -206,9 +200,6 @@ struct ButtonStyle;
             let plt = style.extended_palette();
             
             button::Appearance{
-                // background: Some(Color::from_rgba(0.0, 0.0, 0.0, 0.8).into()),
-                // background: Some(Color::TRANSPARENT.into()),
-                // border_radius: 4.0.into(),
                 background: Some(plt.primary.weak.color.into()),
                 text_color: plt.primary.weak.text,
                 ..self.active(style)
@@ -371,7 +362,7 @@ fn circle<'a>(color: Color) -> quad::Quad{
 
 
 
-fn menu_1<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
+fn menu_1<'a>(_app: &App) -> MenuTree<'a, Message, iced::Renderer>{
     
     let sub_5 = debug_sub_menu(
         "SUB",
@@ -523,7 +514,7 @@ fn menu_3<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer>{
     );
 
     let root = MenuTree::with_children(
-        labeled_button("Controls", Message::Debug("Click Me".into())),
+        debug_button("Controls"),
         vec![
             MenuTree::new(
                 labeled_button("Flip", Message::Flip)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Additional widgets for the Iced GUI library.
-#![deny(missing_docs)]
-#![deny(missing_debug_implementations)]
-#![deny(unused_results)]
+// #![deny(missing_docs)]
+// #![deny(missing_debug_implementations)]
+// #![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::pedantic,
@@ -121,6 +121,14 @@ mod platform {
     #[doc(no_inline)]
     #[cfg(feature = "split")]
     pub use {crate::graphics::split, split::Split};
+
+    #[doc(no_inline)]
+    #[cfg(feature = "menu")]
+    pub use {crate::native::menu};
+
+    #[doc(no_inline)]
+    #[cfg(feature = "quad")]
+    pub use {crate::native::quad};
 }
 
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Additional widgets for the Iced GUI library.
-// #![deny(missing_docs)]
-// #![deny(missing_debug_implementations)]
-// #![deny(unused_results)]
+#![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
+#![deny(unused_results)]
 #![forbid(unsafe_code)]
 #![warn(
     clippy::pedantic,

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -1,4 +1,6 @@
-//! A menu widget
+//! A [`MenuBar`] widget for displaying [`MenuTree`]s
+//!
+//! //! *This API requires the following crate features to be activated: `menu`*
 
 mod menu_tree;
 mod menu_bar;

--- a/src/native/menu.rs
+++ b/src/native/menu.rs
@@ -1,0 +1,9 @@
+//! A menu widget
+
+mod menu_tree;
+mod menu_bar;
+mod flex;
+
+pub use menu_tree::MenuTree;
+pub use menu_bar::{MenuBar, PathHighlight};
+pub use crate::style::menu_bar::{Appearance, StyleSheet};

--- a/src/native/menu/flex.rs
+++ b/src/native/menu/flex.rs
@@ -1,0 +1,235 @@
+//! Distribute elements using a flex-based layout.
+// This code is heavily inspired by the [`druid`] codebase.
+//
+// [`druid`]: https://github.com/xi-editor/druid
+//
+// Copyright 2018 The xi-editor Authors, Héctor Ramón
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use iced_native::layout::{Limits, Node};
+use iced_native::{Alignment, Padding, Point, Size, Element, renderer};
+
+/// The main axis of a flex layout.
+#[derive(Debug)]
+pub enum Axis {
+    /// The horizontal axis
+    Horizontal,
+
+    /// The vertical axis
+    Vertical,
+}
+
+impl Axis {
+    fn main(&self, size: Size) -> f32 {
+        match self {
+            Axis::Horizontal => size.width,
+            Axis::Vertical => size.height,
+        }
+    }
+
+    fn cross(&self, size: Size) -> f32 {
+        match self {
+            Axis::Horizontal => size.height,
+            Axis::Vertical => size.width,
+        }
+    }
+
+    fn pack(&self, main: f32, cross: f32) -> (f32, f32) {
+        match self {
+            Axis::Horizontal => (main, cross),
+            Axis::Vertical => (cross, main),
+        }
+    }
+}
+
+/// Computes the flex layout with the given axis and limits, applying spacing,
+/// padding and alignment to the items as needed.
+///
+/// It returns a new layout [`Node`].
+pub fn resolve<'a, E, Message, Renderer>(
+    axis: Axis,
+    renderer: &Renderer,
+    limits: &Limits,
+    padding: Padding,
+    spacing: f32,
+    align_items: Alignment,
+    items: &[E],
+) -> Node
+where
+    E: std::borrow::Borrow<Element<'a, Message, Renderer>>,
+    Renderer: renderer::Renderer,
+{
+    let limits = limits.pad(padding);
+    let total_spacing = spacing * items.len().saturating_sub(1) as f32;
+    let max_cross = axis.cross(limits.max());
+
+    let mut fill_sum = 0;
+    let mut cross = axis.cross(limits.min()).max(axis.cross(limits.fill()));
+    let mut available = axis.main(limits.max()) - total_spacing;
+
+    let mut nodes: Vec<Node> = Vec::with_capacity(items.len());
+    nodes.resize(items.len(), Node::default());
+
+    if align_items == Alignment::Fill {
+        let mut fill_cross = axis.cross(limits.min());
+
+        items.iter().for_each(|child| {
+            let child = child.borrow();
+            let cross_fill_factor = match axis {
+                Axis::Horizontal => child.as_widget().height(),
+                Axis::Vertical => child.as_widget().width(),
+            }
+            .fill_factor();
+
+            if cross_fill_factor == 0 {
+                let (max_width, max_height) = axis.pack(available, max_cross);
+
+                let child_limits =
+                    Limits::new(Size::ZERO, Size::new(max_width, max_height));
+
+                let layout = child.as_widget().layout(renderer, &child_limits);
+                let size = layout.size();
+
+                fill_cross = fill_cross.max(axis.cross(size));
+            }
+        });
+
+        cross = fill_cross;
+    }
+
+    for (i, child) in items.iter().enumerate() {
+        let child = child.borrow();
+        let fill_factor = match axis {
+            Axis::Horizontal => child.as_widget().width(),
+            Axis::Vertical => child.as_widget().height(),
+        }
+        .fill_factor();
+
+        if fill_factor == 0 {
+            let (min_width, min_height) = if align_items == Alignment::Fill {
+                axis.pack(0.0, cross)
+            } else {
+                axis.pack(0.0, 0.0)
+            };
+
+            let (max_width, max_height) = if align_items == Alignment::Fill {
+                axis.pack(available, cross)
+            } else {
+                axis.pack(available, max_cross)
+            };
+
+            let child_limits = Limits::new(
+                Size::new(min_width, min_height),
+                Size::new(max_width, max_height),
+            );
+
+            let layout = child.as_widget().layout(renderer, &child_limits);
+            let size = layout.size();
+
+            available -= axis.main(size);
+
+            if align_items != Alignment::Fill {
+                cross = cross.max(axis.cross(size));
+            }
+
+            nodes[i] = layout;
+        } else {
+            fill_sum += fill_factor;
+        }
+    }
+
+    let remaining = available.max(0.0);
+
+    for (i, child) in items.iter().enumerate() {
+        let child = child.borrow();
+        let fill_factor = match axis {
+            Axis::Horizontal => child.as_widget().width(),
+            Axis::Vertical => child.as_widget().height(),
+        }
+        .fill_factor();
+
+        if fill_factor != 0 {
+            let max_main = remaining * fill_factor as f32 / fill_sum as f32;
+            let min_main = if max_main.is_infinite() {
+                0.0
+            } else {
+                max_main
+            };
+
+            let (min_width, min_height) = if align_items == Alignment::Fill {
+                axis.pack(min_main, cross)
+            } else {
+                axis.pack(min_main, axis.cross(limits.min()))
+            };
+
+            let (max_width, max_height) = if align_items == Alignment::Fill {
+                axis.pack(max_main, cross)
+            } else {
+                axis.pack(max_main, max_cross)
+            };
+
+            let child_limits = Limits::new(
+                Size::new(min_width, min_height),
+                Size::new(max_width, max_height),
+            );
+
+            let layout = child.as_widget().layout(renderer, &child_limits);
+
+            if align_items != Alignment::Fill {
+                cross = cross.max(axis.cross(layout.size()));
+            }
+
+            nodes[i] = layout;
+        }
+    }
+
+    let pad = axis.pack(padding.left as f32, padding.top as f32);
+    let mut main = pad.0;
+
+    for (i, node) in nodes.iter_mut().enumerate() {
+        if i > 0 {
+            main += spacing;
+        }
+
+        let (x, y) = axis.pack(main, pad.1);
+
+        node.move_to(Point::new(x, y));
+
+        match axis {
+            Axis::Horizontal => {
+                node.align(
+                    Alignment::Start,
+                    align_items,
+                    Size::new(0.0, cross),
+                );
+            }
+            Axis::Vertical => {
+                node.align(
+                    align_items,
+                    Alignment::Start,
+                    Size::new(cross, 0.0),
+                );
+            }
+        }
+
+        let size = node.size();
+
+        main += axis.main(size);
+    }
+
+    let (width, height) = axis.pack(main - pad.0, cross);
+    let size = limits.resolve(Size::new(width, height));
+
+    Node::with_children(size.pad(padding), nodes)
+}

--- a/src/native/menu/menu_bar.rs
+++ b/src/native/menu/menu_bar.rs
@@ -1,0 +1,942 @@
+use iced_native::{
+    Element, Widget, renderer, overlay, 
+    layout, Length, Color, Point, Size, 
+    Padding, Rectangle, Alignment, event,
+    mouse, touch, Shell, Clipboard,
+};
+use iced_native::widget::{tree, Tree, };
+use super::menu_tree::MenuTree;
+use crate::style::menu_bar::StyleSheet;
+
+/// Methods for drawing path highlight
+#[derive(Debug, Clone)]
+pub enum PathHighlight{
+    /// Draw the full path,
+    Full,
+    /// Omit the active item
+    OmitActive,
+    /// Omit the active item if it's not a menu
+    MenuActive
+}
+
+
+struct MenuBarState{
+    pressed: bool,
+    cursor: Point,
+    open: bool,
+    active_root: Option<usize>,
+    indices: Vec<Option<usize>>,
+}
+impl MenuBarState{
+    fn get_flat_indices(&self) -> impl Iterator<Item = usize> + '_{
+        self.indices.iter()
+            .take_while(|i| i.is_some() )
+            .map(|i| i.unwrap() )
+    }
+}
+impl Default for MenuBarState{
+    fn default() -> Self {
+        Self{
+            pressed: false,
+            cursor: Point::new(-0.5, -0.5),
+            open: false,
+            active_root: None,
+            indices: Vec::new(),
+        }
+    }
+}
+
+
+/// A `MenuBar` collects `MenuTree`s and handles 
+/// all the layout, event processing and drawing
+pub struct MenuBar<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    width: Length,
+    height: Length,
+    spacing: u16,
+    padding: Padding,
+    bounds_expand: u16,
+    item_size: Size,
+    path_highlight: Option<PathHighlight>,
+    menu_roots: Vec<MenuTree<'a, Message, Renderer>>,
+    style: <Renderer::Theme as StyleSheet>::Style,
+}
+impl<'a, Message, Renderer> MenuBar<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    /// Creates a new [`MenuBar`] with the given menu roots
+    pub fn new(menu_roots: Vec<MenuTree<'a, Message, Renderer>>) -> Self{
+        let mut menu_roots = menu_roots;
+        menu_roots.iter_mut().for_each(|mr| mr.set_index() );
+
+        Self{
+            width: Length::Shrink,
+            height: Length::Shrink,
+            spacing: 0,
+            padding: Padding::ZERO,
+            bounds_expand: 15,
+            item_size: [150.0, 30.0].into(),
+            path_highlight: Some(PathHighlight::MenuActive),
+            menu_roots,
+            style: <Renderer::Theme as StyleSheet>::Style::default(),
+        }
+    }
+
+    /// Sets the width of the [`MenuBar`]
+    pub fn width(mut self, width: Length) -> Self {
+        self.width = width;
+        self
+    }
+
+    /// Sets the height of the [`MenuBar`]
+    pub fn height(mut self, height: Length) -> Self {
+        self.height = height;
+        self
+    }
+
+    /// Sets the spacing between menu roots
+    pub fn spacing(mut self, units: u16) -> Self {
+        self.spacing = units;
+        self
+    }
+
+    /// Sets the expand value for each menu's check bounds
+    /// 
+    /// When the cursor goes outside of a menu's check bounds, 
+    /// the menu will be closed automatically, this value expands
+    /// the check bounds
+    pub fn bounds_expand(mut self, value: u16) -> Self {
+        self.bounds_expand = value;
+        self
+    }
+
+    /// Sets the [`Padding`] of the [`MenuBar`]
+    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
+        self.padding = padding.into();
+        self
+    }
+
+    /// Sets the [`Size`] of each menu item
+    pub fn item_size(mut self, item_size: impl Into<Size>) -> Self{
+        self.item_size = item_size.into();
+        self
+    }
+
+    /// Sets the method for drawing path highlight
+    pub fn path_highlight(mut self, path_highlight: Option<PathHighlight>) -> Self{
+        self.path_highlight = path_highlight;
+        self
+    }
+
+    /// Sets the style of the menu bar and its menus
+    pub fn style(mut self, style: impl Into<<Renderer::Theme as StyleSheet>::Style>) -> Self{
+        self.style = style.into();
+        self
+    }
+
+} 
+impl<'a, Message, Renderer> Widget<Message, Renderer> for MenuBar<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+    
+    fn state(&self) -> tree::State {
+        tree::State::new(MenuBarState::default())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        /*
+        menu bar
+            menu root 1 (stateless)
+                flat tree
+            menu root 2 (stateless)
+                flat tree
+            ...
+        */
+        
+        self.menu_roots.iter().map(|root|{
+            let mut tree = Tree::empty();
+            let flat = root.flattern().iter().map(|mt|{
+                Tree::new(mt.item.as_widget())
+            }).collect();
+            tree.children = flat;
+            tree
+        }).collect()
+    }
+
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        use super::flex;
+
+        let limits = limits.width(self.width).height(self.height);
+        let children = self.menu_roots.iter().map(|root| &root.item ).collect::<Vec<_>>();
+        flex::resolve(
+            flex::Axis::Horizontal,
+            renderer,
+            &limits,
+            self.padding,
+            self.spacing as f32,
+            Alignment::Center,
+            &children,
+        )
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: event::Event,
+        layout: layout::Layout<'_>,
+        cursor_position: Point,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        use event::{Event::*, Status::*};
+        use mouse::{Event::*, Button::Left};
+        use touch::{Event::*, };
+
+        process_root_events(
+            &mut self.menu_roots, 
+            cursor_position, 
+            tree, 
+            event.clone(), 
+            layout, 
+            renderer, 
+            clipboard, 
+            shell
+        );
+
+        let state = tree.state.downcast_mut::<MenuBarState>();
+
+        match event {
+            Mouse(ButtonReleased(Left)) |
+            Touch(FingerLifted {..}) |
+            Touch(FingerLost {..})  => {
+                if state.indices.is_empty()
+                && layout.bounds().contains(cursor_position){
+                    init_root_menu(
+                        state, 
+                        layout.children().map(|lo| lo.bounds() ), 
+                        cursor_position
+                    );
+                    state.cursor = cursor_position;
+                    state.open = true;
+                }
+            },
+            _ => (),
+        }
+        Ignored
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &<Renderer as renderer::Renderer>::Theme,
+        style: &renderer::Style,
+        layout: layout::Layout<'_>,
+        cursor_position: Point,
+        viewport: &Rectangle,
+    ) {
+        let state = tree.state.downcast_ref::<MenuBarState>();
+
+        let position = if state.open
+        && (cursor_position.x < 0.0
+        || cursor_position.y < 0.0){
+            state.cursor
+        }else{
+            cursor_position
+        };
+
+        // draw path highlight
+        if let Some(_) = self.path_highlight{
+            let styling = theme.appearance(&self.style);
+            if let Some(active) = state.active_root{
+                let active_bounds = layout.clone().children()
+                    .skip(active).next().unwrap().bounds();
+                let path_quad = renderer::Quad{
+                    bounds: active_bounds,
+                    border_radius: styling.border_radius.into(),
+                    border_width: 0.0,
+                    border_color: Color::TRANSPARENT,
+                };
+                let path_color = styling.path;
+                renderer.fill_quad(path_quad, path_color);
+            }
+        }
+
+        self.menu_roots.iter()
+        .zip(&tree.children)
+        .zip(layout.children())
+        .for_each(|((root, t), lo)|{
+            root.item.as_widget().draw(
+                &t.children[root.index], 
+                renderer, 
+                theme, 
+                style, 
+                lo,
+                position,
+                viewport
+            );
+        })
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: layout::Layout<'_>,
+        _renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        let state = tree.state.downcast_ref::<MenuBarState>();
+        if !state.open { return None; }
+
+        Some(Menu{
+            tree,
+            menu_roots: &mut self.menu_roots,
+            bounds_expand: self.bounds_expand,
+            item_size: self.item_size,
+            bar_bounds: layout.bounds(),
+            root_bounds_list: layout.children()
+                .map(|lo| lo.bounds())
+                .collect(),
+            path_highlight: self.path_highlight.clone(),
+            style: &self.style,
+        }.overlay())
+    }
+}
+impl<'a, Message, Renderer> From<MenuBar<'a, Message, Renderer>> for Element<'a, Message, Renderer>
+where
+    Message: 'a,
+    Renderer: 'a + renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    fn from(value: MenuBar<'a, Message, Renderer>) -> Self {
+        Self::new(value)
+    }
+}
+
+
+struct Menu<'a, 'b, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    tree: &'b mut Tree,
+    menu_roots: &'b mut Vec<MenuTree<'a, Message, Renderer>>,
+    bounds_expand: u16,
+    item_size: Size,
+    bar_bounds: Rectangle,
+    root_bounds_list: Vec<Rectangle>,
+    path_highlight: Option<PathHighlight>,
+    style: &'b <Renderer::Theme as StyleSheet>::Style,
+}
+impl<'a, 'b, Message, Renderer> Menu<'a, 'b, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    fn overlay(self) -> overlay::Element<'b, Message, Renderer>{
+        overlay::Element::new(
+            Point::ORIGIN,
+            Box::new(self)
+        )
+    }
+}
+impl<'a, 'b, Message, Renderer> overlay::Overlay<Message, Renderer> for Menu<'a, 'b, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    fn layout(
+        &self,
+        renderer: &Renderer,
+        bounds: Size,
+        _position: Point,
+    ) -> layout::Node {
+        /* 
+        Each menu_node corresponds to a children_node, a parent_node, and a check_node
+        
+        A children node is a rectangle of the children part, a bounding box of its child nodes
+
+        A parent node is a rectangle of the parent part.
+
+        A check node is a rectangle for iniside checks, usually an expanded version of 
+        the children_node
+
+        These are info needed by on_event() and draw()
+        */
+
+        /* 
+        root_node
+            menu_node_a
+                children_node
+                    child_node
+                    child_node
+                    ...
+                parent_node
+                check_node
+            menu_node_b
+                children_node
+                    child_node
+                    child_node
+                    ...
+                parent_node
+                check_node
+            ...
+        */
+        
+        let state = self.tree.state.downcast_ref::<MenuBarState>();
+
+        let Some(active_root) = state.active_root else{
+            return layout::Node::new(Size::INFINITY);
+        };
+        let root_bounds = self.root_bounds_list[active_root];
+        let item_width = self.item_size.width;
+        let item_height = self.item_size.height;
+
+        // init
+        let mut menu_root = &self.menu_roots[active_root];
+        let mut parent_bounds = root_bounds;
+        let mut aop_settings = [false, true, true, false];
+
+        // calc menu nodes
+        let menu_nodes = state.indices.iter().map(|i|{
+            let children_count = menu_root.children.len() as f32;
+            let children_size = Size::new(item_width, item_height * children_count);
+            let (pos, mask) = adaptive_open_direction(parent_bounds, children_size, bounds, aop_settings);
+            let children_bounds = Rectangle::new(
+                pos,
+                children_size,
+            );
+
+            // calc child nodes
+            let child_limits = layout::Limits::new(Size::ZERO, self.item_size);
+            let child_nodes = menu_root.children.iter().enumerate().map(|(j, mt)|{
+                let mut node = mt.item.as_widget().layout(renderer, &child_limits);
+                let center_offset = (self.item_size.height - node.size().height)*0.5;
+                node.move_to(Point::new(0.0, (j as f32) * item_height + center_offset));
+                node
+            }).collect::<Vec<_>>();
+
+            // calc parent node
+            let mut parent_node = layout::Node::new(parent_bounds.size());
+            parent_node.move_to(parent_bounds.position());
+
+            // calc check node
+            let mut padding = [0;4];
+            padding.iter_mut().enumerate().for_each(|(i, p)| {
+                *p = mask[i] * self.bounds_expand;
+            });
+            
+            let check_bounds = pad_rectangle(children_bounds, padding.into());
+            let mut check_node = layout::Node::new(check_bounds.size());
+            check_node.move_to(check_bounds.position());
+
+            // update for next iteration
+            if let Some(active) = i{
+                menu_root = &menu_root.children[*active];
+                parent_bounds = child_nodes[*active].bounds() + 
+                    (children_bounds.position() - Point::ORIGIN);
+                aop_settings = [true, true, false, true];
+            }
+
+            // calc children node
+            let mut children_node = layout::Node::with_children(children_bounds.size(), child_nodes);
+            children_node.move_to(children_bounds.position());
+
+            // menu node
+            layout::Node::with_children(
+                Size::INFINITY, 
+                vec![children_node, parent_node, check_node]
+            )
+        }).collect::<Vec<_>>();
+
+        let root_node = layout::Node::with_children(Size::INFINITY, menu_nodes);
+        root_node
+    }
+
+    fn on_event(
+        &mut self,
+        event: event::Event,
+        layout: layout::Layout<'_>,
+        cursor_position: Point,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+    ) -> event::Status {
+        use event::{Event::*, Status::*};
+        use mouse::{Event::*, Button::Left};
+        use touch::{Event::*, };
+
+        process_menu_events(
+            &mut self.tree, 
+            &mut self.menu_roots, 
+            event.clone(), 
+            layout, 
+            cursor_position, 
+            renderer, 
+            clipboard, 
+            shell
+        );
+
+        match event {
+            Mouse(CursorMoved { position }) |
+            Touch(FingerMoved { position,.. }) => process_overlay_events(self, layout, position),
+            
+            Mouse(ButtonPressed(Left)) |
+            Touch(FingerPressed {..}) => {
+                let state = self.tree.state.downcast_mut::<MenuBarState>();
+                state.pressed = true;
+                Captured
+            },
+
+            Mouse(ButtonReleased(Left)) |
+            Touch(FingerLifted {..}) => {
+                let state = self.tree.state.downcast_mut::<MenuBarState>();
+                state.pressed = false;
+
+                if self.bar_bounds.contains(cursor_position){
+                    state.open = false;
+                    state.indices.clear();
+                    state.active_root = None;
+                    state.cursor = cursor_position;
+                    Captured
+                }else{
+                    Ignored
+                }
+            },
+            _ => Ignored
+        }
+    }
+
+    fn draw(
+        &self,
+        renderer: &mut Renderer,
+        theme: &Renderer::Theme,
+        style: &renderer::Style,
+        layout: layout::Layout<'_>,
+        cursor_position: Point,
+    ) {
+        let styling = theme.appearance(self.style);
+
+        let state = self.tree.state.downcast_ref::<MenuBarState>();
+        let Some(active_root) = state.active_root else{ return; };
+
+        let tree = &self.tree.children[active_root].children;
+        let root = &self.menu_roots[active_root];
+        
+        let indices = state.get_flat_indices().collect::<Vec<_>>();
+
+        state.indices.iter().enumerate()
+            .zip(layout.children())
+            .fold(root, |menu_root, ((e, i), menu_layout)|{
+            
+            let mut c = menu_layout.children();
+            let children_layout = c.next().unwrap();
+            let children_bounds = children_layout.bounds();
+
+            let draw_menu_background = |r: &mut Renderer|{
+                let menu_quad = renderer::Quad{
+                    bounds: pad_rectangle(children_bounds, styling.background_expand.into()),
+                    border_radius: styling.border_radius.into(),
+                    border_width: styling.border_width,
+                    border_color: styling.border_color,
+                };
+                let menu_color = styling.background;
+                r.fill_quad(menu_quad, menu_color);
+            };
+
+            let draw_path_highlight = |r: &mut Renderer, active:usize|{
+                let active_bounds = children_layout.children()
+                    .skip(active).next().unwrap().bounds();
+                let path_quad = renderer::Quad{
+                    bounds: active_bounds,
+                    border_radius: styling.border_radius.into(),
+                    border_width: 0.0,
+                    border_color: Color::TRANSPARENT,
+                };
+                let path_color = styling.path;
+                r.fill_quad(path_quad, path_color);
+            };
+
+            let draw_items = |r: &mut Renderer|{
+                menu_root.children.iter()
+                    .zip(children_layout.clone().children())
+                    .for_each(|(mt, clo)|{
+                    mt.item.as_widget().draw(
+                        &tree[mt.index], 
+                        r, 
+                        theme, 
+                        style, 
+                        clo, 
+                        cursor_position, 
+                        &children_layout.bounds()
+                    );
+                });
+            };
+
+            let draw_path = match &self.path_highlight{
+                Some(ph) => match ph{
+                    PathHighlight::Full => true,
+                    PathHighlight::OmitActive => {
+                        indices.len() > 0 && e < indices.len() - 1
+                    },
+                    PathHighlight::MenuActive => {
+                        e < state.indices.len() - 1
+                    }
+                },
+                None => false,
+            };
+
+            let draw_menu = |r: &mut Renderer|{
+                draw_menu_background(r);
+
+                if let (true, Some(active)) = (draw_path, i){
+                    draw_path_highlight(r, *active);
+                }
+
+                draw_items(r);
+            };
+
+            renderer.with_layer(layout.bounds(), draw_menu);
+
+            // only the last menu can have a None active index
+            if let Some(active) = i {
+                &menu_root.children[*active]
+            }else{
+                menu_root
+            }
+        });
+    }
+    
+}
+
+
+fn pad_rectangle(rect: Rectangle, padding: Padding) -> Rectangle{
+    Rectangle{
+        x: rect.x - padding.left as f32,
+        y: rect.y - padding.top as f32,
+        width: rect.width + padding.horizontal() as f32,
+        height: rect.height + padding.vertical() as f32,
+    }
+}
+
+fn process_root_events<'a, 'b, Message, Renderer: renderer::Renderer>(
+    menu_roots: &mut Vec<MenuTree<'a, Message, Renderer>>,
+    position: Point,
+    tree: &mut Tree,
+    event: event::Event,
+    layout: layout::Layout<'_>,
+    renderer: &Renderer,
+    clipboard: &mut dyn Clipboard,
+    shell: &mut Shell<'_, Message>,
+) -> event::Status{
+    use event::Status;
+    menu_roots.iter_mut()
+        .zip(&mut tree.children)
+        .zip(layout.children())
+        .map(|((root, t), lo)|{
+            // assert!(t.tag == tree::Tag::stateless());
+            root.item.as_widget_mut().on_event(
+                &mut t.children[root.index], 
+                event.clone(), 
+                lo, 
+                position, 
+                renderer, 
+                clipboard, 
+                shell
+            )
+        }).fold(Status::Ignored, Status::merge)
+}
+
+fn init_root_menu<T, B>(
+    state: &mut MenuBarState,
+    root_bounds_list: T,
+    position: Point,
+) -> Option<usize>
+where
+    T: Iterator<Item = B>,
+    B: std::borrow::Borrow<Rectangle>,
+{
+    for (i, rect) in root_bounds_list.enumerate(){
+        if rect.borrow().contains(position){
+            state.active_root = Some(i);
+            state.indices.push(None);
+            return Some(i);
+        }
+    }
+    return None;
+}
+
+fn process_menu_events<'a, 'b, Message, Renderer: renderer::Renderer>(
+    tree: &'b mut Tree,
+    menu_roots: &'b mut Vec<MenuTree<'a, Message, Renderer>>,
+    event: event::Event,
+    layout: layout::Layout<'_>,
+    cursor_position: Point,
+    renderer: &Renderer,
+    clipboard: &mut dyn Clipboard,
+    shell: &mut Shell<'_, Message>,
+) -> event::Status {
+    use event::Status;
+
+    let state = tree.state.downcast_mut::<MenuBarState>();
+    let Some(active_root) = state.active_root else { return Status::Ignored; };
+    
+    let indices = state.get_flat_indices().collect::<Vec<_>>();
+
+    if indices.is_empty() { return Status::Ignored; }
+    
+    // get active item
+    let mt = indices.iter()
+        .fold(&mut menu_roots[active_root], |mt, &i|{
+            &mut mt.children[i]
+        });
+    
+    // get layout
+    let last_index = indices.last().unwrap();
+    let menu_layout = layout.children().skip(indices.len()-1).next().unwrap();
+    let children_layout = menu_layout.children().next().unwrap();
+    let child_layout = children_layout.children().skip(*last_index).next().unwrap();
+    
+    // widget tree
+    let tree = &mut tree.children[active_root].children[mt.index];
+
+    // process only the last widget
+    mt.item.as_widget_mut().on_event(
+        tree, 
+        event, 
+        child_layout,
+        cursor_position, 
+        renderer, 
+        clipboard, 
+        shell
+    )
+
+    // state.indices.iter()
+    //     .zip(layout.children())
+    //     .fold(root, |menu_root, (i, mlo)|{
+    //     menu_root.children.iter_mut()
+    //         .zip(mlo.children().skip(1))
+    //         .for_each(|(mt, clo)|{
+    //         mt.item.as_widget_mut().on_event(
+    //             &mut tree[mt.index], 
+    //             event.clone(), 
+    //             clo, 
+    //             cursor_position, 
+    //             renderer, 
+    //             clipboard, 
+    //             shell
+    //         );
+    //     });
+    // 
+    //     if let Some(active) = i {
+    //         &mut menu_root.children[*active]
+    //     }else {
+    //         menu_root
+    //     }
+    // });
+}
+
+fn process_overlay_events<'a, 'b, Message, Renderer: renderer::Renderer>(
+    menu: &mut Menu<'a, 'b, Message, Renderer>,
+    layout: layout::Layout<'_>,
+    position: Point,
+) -> event::Status
+where
+    Renderer: renderer::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    use event::Status::*;
+    /* 
+    if no active root:
+        init root menu
+    else:
+        remove invalid menu
+        update active item
+        if active item is a menu:
+            add menu
+    */
+
+    let state = menu.tree.state.downcast_mut::<MenuBarState>();
+    
+    /* When overlay is running, cursor_position in any widget method will go negative
+    but I still want Widget::draw() to react to cursor movement */
+    state.cursor = position;
+
+    // init
+    let Some(active_root) = state.active_root else{
+        init_root_menu(state, menu.root_bounds_list.iter(), position);
+        return Ignored;
+    };
+
+    if state.pressed { return Ignored; }
+    
+    // get menu_bounds
+    let mut menu_bounds = layout.children() // menu_nodes
+        .map(|lo|{
+            let mut c = lo.children();
+            let children_bounds = c.next().unwrap().bounds();
+            let parent_bounds = c.next().unwrap().bounds();
+            let check_bounds = c.next().unwrap().bounds();
+            [children_bounds, parent_bounds, check_bounds]
+        }).collect::<Vec<_>>();
+    
+    if state.indices.len() != menu_bounds.len() { return Ignored; }
+    // assert_eq!(state.indices.len(), menu_bounds.len());
+
+    // remove invalid menu
+    for i in (0..state.indices.len()).rev(){
+        let [_, pb, ckb] = menu_bounds[i];
+
+        if pb.contains(position) || ckb.contains(position){
+            break;
+        }
+        state.indices.pop();
+        menu_bounds.pop();
+    }
+
+
+    // update active item
+    let Some(last_index) = state.indices.last_mut() else{
+        // no menus left
+        state.active_root = None;
+
+        // keep state.open when the cursor is still inside the menu bar
+        // this allows the overlay to keep drawing when the cursor is
+        // moving aroung the menu bar
+        if !menu.bar_bounds.contains(position){
+            state.open = false;
+        }
+        return Captured;
+    };
+
+    let [last_cb, last_pb, _] = menu_bounds.last().unwrap();
+
+    if last_pb.contains(position){
+        // cursor is in the parent part
+        *last_index = None;
+        return Captured;
+    }
+    // cursor is in the children part
+
+    // calc new index
+    let menu_pos = last_cb.position();
+
+    let height_diff = (position.y - menu_pos.y)
+        .clamp(0.0, last_cb.height - 0.001);
+    let new_index = (height_diff / menu.item_size.height).floor() as usize;
+    *last_index = Some(new_index);
+    
+
+    // get new active item
+    let active_menu_root = &menu.menu_roots[active_root];
+    let item = state.get_flat_indices()
+        .fold(active_menu_root, |mt, i|{
+            &mt.children[i]
+        });
+
+    // check if new item is a menu
+    if !item.children.is_empty(){
+        state.indices.push(None);
+    }
+
+    Captured
+}
+
+fn adaptive_open_direction(
+    parent_bounds: Rectangle,
+    children_size: Size,
+    bounds: Size,
+    setttings: [bool;4],
+) -> (Point, [u16;4]) {
+    /*
+    Imagine there're two sticks, parent and child
+    parent: o-----o
+    child:  o----------o
+
+    Now we align the child to the parent in one dimension
+    There are 4 possibilities:
+
+    1. to the right
+                o-----oo----------o
+
+    2. to the right but allow overlaping
+                o-----o
+                o----------o
+
+    3. to the left
+    o----------oo-----o
+
+    4. to the left but allow overlaping
+                o-----o
+           o----------o
+
+    The child goes to the right by default, if the right space runs out
+    it goes to the left, whether to use overlap is the caller's decision
+
+    This can be applied to any direction
+    */
+
+    let [horizontal, vertical, horizontal_overlap, vertical_overlap] = setttings;
+
+    let calc_adaptive = |parent_pos, parent_size, child_size, max_size, on, overlap|{
+        let mut padding_mask = [1,1];
+
+        if on{
+            let space_left = parent_pos;
+            let space_right = max_size - parent_pos - parent_size;
+    
+            if space_left > space_right && child_size > space_right{
+                let value = if overlap{
+                    parent_pos - child_size + parent_size
+                }else{
+                    padding_mask[1] = 0;
+                    parent_pos - child_size
+                };
+                return (value, padding_mask)
+            }
+        }
+
+        let value = if overlap{
+            parent_pos
+        }else{
+            padding_mask[0] = 0;
+            parent_pos + parent_size
+        };
+        return (value, padding_mask)
+    };
+
+    let (x, px) = calc_adaptive(
+        parent_bounds.x, parent_bounds.width, 
+        children_size.width, bounds.width, 
+        horizontal, horizontal_overlap
+    );
+    let (y, py) = calc_adaptive(
+        parent_bounds.y, parent_bounds.height, 
+        children_size.height, bounds.height, 
+        vertical, vertical_overlap
+    );
+
+    let padding_mask = [py[0], px[1], py[1], px[0]];
+
+    ([x,y].into(), padding_mask)
+
+}
+

--- a/src/native/menu/menu_bar.rs
+++ b/src/native/menu/menu_bar.rs
@@ -498,7 +498,9 @@ where
 
         match event {
             Mouse(CursorMoved { position }) |
-            Touch(FingerMoved { position,.. }) => process_overlay_events(self, layout, position).merge(menu_status),
+            Touch(FingerMoved { position,.. }) => {
+                process_overlay_events(self, layout, position).merge(menu_status)
+            },
             
             Mouse(ButtonPressed(Left)) |
             Touch(FingerPressed {..}) => {
@@ -777,7 +779,8 @@ where
     */
 
     let state = menu.tree.state.downcast_mut::<MenuBarState>();
-    
+    if !state.open {return Ignored;}
+
     /* When overlay is running, cursor_position in any widget method will go negative
     but I still want Widget::draw() to react to cursor movement */
     state.cursor = position;

--- a/src/native/menu/menu_tree.rs
+++ b/src/native/menu/menu_tree.rs
@@ -1,0 +1,104 @@
+use iced_native::{
+    Element, renderer
+};
+
+/// Nested menu is essentially a tree of items, a menu is a collection of items
+/// a menu itself can also be an item of another menu. 
+/// 
+/// A `MenuTree` represents a node in the tree, it holds a widget as a menu item 
+/// for its parent, and a list of menu tree as child nodes. 
+/// Conceptually a node is either a menu(inner node) or an item(leaf node), 
+/// but there's no need to explicitly distinguish them here, if a menu tree 
+/// has children, it's a menu, otherwise it's an item
+#[allow(missing_debug_implementations)]
+pub struct MenuTree<'a, Message, Renderer>{
+    /// The menu tree will be flatten into a vector to build a linear widget tree, 
+    /// the `index` field is the index of the item in that vector
+    pub(super) index: usize,
+    
+    pub(super) item: Element<'a, Message, Renderer>,
+    pub(super) children: Vec<MenuTree<'a, Message, Renderer>>
+}
+impl<'a, Message, Renderer> MenuTree<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    pub fn new(
+        item: impl Into<Element<'a, Message, Renderer>>, 
+    ) -> Self{
+        Self{
+            index: 0,
+            item: item.into(),
+            children: Vec::new(),
+        }
+    }
+
+    pub fn with_children(
+        item: impl Into<Element<'a, Message, Renderer>>, 
+        children: Vec<impl Into<MenuTree<'a, Message, Renderer>>>
+    ) -> Self{
+        Self{
+            index: 0,
+            item: item.into(),
+            children: children.into_iter().map(|item| item.into() ).collect(),
+        }
+    }
+
+
+    /* Keep `set_index()` and `flattern()` recurse in the same order */
+    
+    /// Set the index of each item
+    pub(super) fn set_index(&mut self){
+        fn rec<'a, Message, Renderer>(
+            mt: &mut MenuTree<'a, Message, Renderer>, 
+            count: &mut usize)
+        {
+            // keep items under the same menu line up
+            mt.children.iter_mut().for_each(|c|{
+                c.index = *count;
+                *count += 1;
+            });
+
+            mt.children.iter_mut().for_each(|c|{
+                rec(c, count)
+            });
+        }
+        
+        let mut count = 0;
+        self.index = count;
+        count += 1;
+        rec(self, &mut count)
+    }
+
+    /// Flatten the menu tree
+    pub(super) fn flattern(&'a self) -> Vec<&Self>{
+        fn rec<'a, Message, Renderer>(
+            mt: &'a MenuTree<'a, Message, Renderer>,
+            flat: &mut Vec<&MenuTree<'a, Message, Renderer>>,
+        ){
+            mt.children.iter().for_each(|c|{
+                flat.push(c);
+            });
+
+            mt.children.iter().for_each(|c|{
+                rec(c, flat);
+            });
+        }
+        
+        let mut flat = Vec::new();
+        flat.push(self);
+        rec(self, &mut flat);
+
+        flat
+    }
+
+}
+
+impl<'a, Message, Renderer> From<Element<'a, Message, Renderer>> for MenuTree<'a, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn from(value: Element<'a, Message, Renderer>) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/native/menu/menu_tree.rs
+++ b/src/native/menu/menu_tree.rs
@@ -23,6 +23,7 @@ impl<'a, Message, Renderer> MenuTree<'a, Message, Renderer>
 where
     Renderer: renderer::Renderer,
 {
+    /// Create a new menu tree from a widget
     pub fn new(
         item: impl Into<Element<'a, Message, Renderer>>, 
     ) -> Self{
@@ -33,6 +34,7 @@ where
         }
     }
 
+    /// Create a menu tree from a widget and a vector of sub trees
     pub fn with_children(
         item: impl Into<Element<'a, Message, Renderer>>, 
         children: Vec<impl Into<MenuTree<'a, Message, Renderer>>>

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -76,3 +76,9 @@ pub use time_picker::TimePicker;
 pub mod wrap;
 #[cfg(feature = "wrap")]
 pub use wrap::Wrap;
+
+#[cfg(feature = "menu")]
+pub mod menu;
+
+#[cfg(feature = "quad")]
+pub mod quad;

--- a/src/native/quad.rs
+++ b/src/native/quad.rs
@@ -1,0 +1,130 @@
+use iced_native::{
+    Element, Widget, renderer, 
+    layout, Length, Color, Point, 
+    Padding, Rectangle, 
+};
+use iced_native::widget::{Tree};
+
+pub enum InnerBounds {
+    Ratio(f32, f32),
+    Padding(Padding),
+    Square(f32),
+    Custom(Box<dyn Fn(Rectangle)->Rectangle>)
+}
+impl InnerBounds{
+    fn get_bounds(&self, outer_bounds:Rectangle) -> Rectangle{
+        use InnerBounds::*;
+        match self {
+            Ratio(w, h) => {
+                let width = w * outer_bounds.width;
+                let height = h * outer_bounds.height;
+                let x = outer_bounds.x + (outer_bounds.width - width)*0.5;
+                let y = outer_bounds.y + (outer_bounds.height - height)*0.5;
+                Rectangle{ x, y, width, height }
+            },
+            Padding(p) => {
+                let x = outer_bounds.x + p.left as f32;
+                let y = outer_bounds.y + p.top as f32;
+                let width = outer_bounds.width - p.horizontal() as f32;
+                let height = outer_bounds.width - p.vertical() as f32;
+                Rectangle{ x, y, width, height }
+            },
+            Square(l) => {
+                let width = *l;
+                let height = *l;
+                let x = outer_bounds.x + (outer_bounds.width - width)*0.5;
+                let y = outer_bounds.y + (outer_bounds.height - height)*0.5;
+                Rectangle{ x, y, width, height }
+            }
+            Custom(f) => f(outer_bounds)
+        }
+    }
+}
+
+/// A dummy widget that draws a quad
+pub struct Quad{
+    pub width: Length,
+    pub height: Length,
+    pub color: Color,
+    pub background: Option<Color>,
+    pub inner_bounds: InnerBounds,
+    pub border_radius: renderer::BorderRadius,
+    pub border_width: f32,
+    pub border_color: Color,
+}
+impl Default for Quad{
+    fn default() -> Self {
+        Self{
+            width: Length::Fill,
+            height: Length::Fill,
+            color: Color::from([0.5;3]),
+            background: None,
+            inner_bounds: InnerBounds::Ratio(0.5, 0.5),
+            border_radius: 0.0.into(),
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT,
+        }
+    }
+}
+impl<Message, Renderer> Widget<Message, Renderer> for Quad
+where
+    Renderer: renderer::Renderer,
+{
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.width
+    }
+
+    fn layout(
+        &self,
+        _renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let limits = limits.width(self.width).height(self.height);
+        layout::Node::new(limits.max())
+    }
+
+    fn draw(
+        &self,
+        _state: &Tree,
+        renderer: &mut Renderer,
+        _theme: &<Renderer as renderer::Renderer>::Theme,
+        _style: &renderer::Style,
+        layout: layout::Layout<'_>,
+        _cursor_position: Point,
+        _viewport: &Rectangle,
+    ) {
+        if let Some(b) = self.background{
+            renderer.fill_quad(
+                renderer::Quad{
+                    bounds: layout.bounds(),
+                    border_radius: self.border_radius,
+                    border_width: self.border_width,
+                    border_color: self.border_color,
+                },
+                b
+            )
+        }
+        renderer.fill_quad(
+            renderer::Quad{
+                bounds: self.inner_bounds.get_bounds(layout.bounds()),
+                border_radius: self.border_radius,
+                border_width: self.border_width,
+                border_color: self.border_color,
+            },
+            self.color
+        )
+    }
+}
+impl<Message, Renderer> From<Quad> for Element<'_, Message, Renderer>
+where
+    Renderer: renderer::Renderer,
+{
+    fn from(value: Quad) -> Self {
+        Self::new(value)
+    }
+}
+

--- a/src/native/quad.rs
+++ b/src/native/quad.rs
@@ -1,14 +1,23 @@
+//! A dummy widget that draws a quad
+//!
+//! //! *This API requires the following crate features to be activated: `quad`*
+
 use iced_native::{
     Element, Widget, renderer, 
     layout, Length, Color, Point, 
     Padding, Rectangle, 
 };
 use iced_native::widget::{Tree};
-
+/// Methods for creating inner bounds
+#[allow(missing_debug_implementations)]
 pub enum InnerBounds {
+    /// Create inner bounds ratio to the outer bounds
     Ratio(f32, f32),
+    /// Create inner bounds by padding the outer bounds
     Padding(Padding),
+    /// Create square inner bounds
     Square(f32),
+    /// Create inner bounds with a custom function
     Custom(Box<dyn Fn(Rectangle)->Rectangle>)
 }
 impl InnerBounds{
@@ -42,14 +51,23 @@ impl InnerBounds{
 }
 
 /// A dummy widget that draws a quad
+#[allow(missing_debug_implementations)]
 pub struct Quad{
+    /// Width of the quad
     pub width: Length,
+    /// Height of the quad
     pub height: Length,
+    /// Color of the quad
     pub color: Color,
+    /// Background color of the quad
     pub background: Option<Color>,
+    /// Methods for creating inner bounds
     pub inner_bounds: InnerBounds,
+    /// Border radius of the Quad
     pub border_radius: renderer::BorderRadius,
+    /// Border width of the quad
     pub border_width: f32,
+    /// Border color of the quad
     pub border_color: Color,
 }
 impl Default for Quad{

--- a/src/style/menu_bar.rs
+++ b/src/style/menu_bar.rs
@@ -1,0 +1,68 @@
+//! Change the appearance of menu bars and their menus.
+use iced_native::Color;
+use iced_style::Theme;
+
+/// The appearance of a menu bar and its menus.
+#[derive(Debug, Clone, Copy)]
+pub struct Appearance {
+    /// The background color of the menu bar and its menus.
+    pub background: Color,
+    /// The border width of the menu bar and its menus.
+    pub border_width: f32,
+    /// The border radius of the menu bar and its menus.
+    pub border_radius: [f32;4],
+    /// The border [`Color`] of the menu bar and its menus.
+    pub border_color: Color,
+    /// The expand value of the menus' background
+    pub background_expand: [u16;4],
+    /// The highlighted path [`Color`] of the the menu bar and its menus.
+    pub path: Color,
+}
+impl std::default::Default for Appearance {
+    fn default() -> Self {
+        Self {
+            background: Color::from([0.85;3]),
+            border_width: 1.0,
+            border_radius: [4.0;4],
+            border_color: Color::from([0.5;3]),
+            background_expand: [4;4],
+            path: Color::from([0.0, 0.0, 0.0, 0.3]),
+        }
+    }
+}
+
+/// The style sheet of a menu bar and its menus.
+pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
+    /// Produces the [`Appearance`] of a menu bar and its menus.
+    fn appearance(&self, style: &Self::Style) -> Appearance;
+}
+
+
+#[derive(Default)]
+/// The style of a menu bar and its menus
+pub enum MenuBarStyle{
+    /// The default style.
+    #[default]
+    Default,
+    /// A [`Theme`] that uses a [`Custom`] palette.
+    Custom(Box<dyn StyleSheet<Style = Theme>>),
+}
+impl StyleSheet for Theme{
+    type Style = MenuBarStyle;
+
+    fn appearance(&self, _style: &Self::Style) -> Appearance {
+        let palette = self.extended_palette();
+
+        Appearance{
+            background: palette.background.base.color,
+            border_width: 1.0,
+            border_radius: [6.0;4],
+            border_color: palette.background.weak.color,
+            background_expand: [6;4],
+            path: palette.primary.weak.color,
+        }
+    }
+}

--- a/src/style/menu_bar.rs
+++ b/src/style/menu_bar.rs
@@ -43,6 +43,7 @@ pub trait StyleSheet {
 
 #[derive(Default)]
 /// The style of a menu bar and its menus
+#[allow(missing_debug_implementations)]
 pub enum MenuBarStyle{
     /// The default style.
     #[default]

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -46,3 +46,6 @@ pub use selection_list::SelectionListStyles;
 pub mod split;
 #[cfg(feature = "split")]
 pub use split::SplitStyles;
+
+// #[cfg(feature = "menu")]
+pub mod menu_bar;


### PR DESCRIPTION

https://user-images.githubusercontent.com/49757619/217568459-23456f5b-8750-4385-9bb5-6851680dea87.mp4

I did saw the other pr and read their code, didn't quite like it so I wrote one, also I have no idea why the other one seems abandoned.

In the earlier version I tried to put parts of the layout calculation in Widget::on_event(), and output it through the widget state to Overlay::layout(), it makes the most sense to do so bc the layout is dynamic and reacts to events, but iced expects layout before event handling, apart from that, I can't get the viewport size in on_event(), without which there's no way to achieve adaptive open direction

So I went the extra mile to rewrite it so that they are completely separated and the new layout will be calculated after the previous event update. But it's so error prone and causes a ton of weird bugs. I've been trying to clean it up but it's still messy af. Right now it's fairly stable, as least in my tests

I'm quite satisfied with the result tho, it supports any widget, adaptive open direction and path highlight. 

There're still some limitations:
- No adaptive menu width, bc I can't get a minimum required width from any widget, I could have it manually set for each menu, but it's such a hassle I doubt anyone wanna do that.

- No arbitrary item height. It's more of a design choice than limitation, I could support that with flex::resolve(), but when users do want uniform height, which is almost always, they have to manually sync the height of each widget, that's a problem when some widgets don't let you set its height. Maybe it's good to have an option, what do you guys think?

- No scrolling, yet.


Right now the API is a bit verbose, you have to wrap a MenuTree::new() to almost every widget
```
let sub_menu = MenuTree::with_children(
        button("sub menu"),
        vec![
            MenuTree::new(button("item")),
            
        ]
    );
```
