### PR TITLE
Adaptive root direction

### DIFF
--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -48,7 +48,8 @@ enum Message {
     CheckChange(bool),
     ToggleChange(bool),
     ColorChange(Color),
-    Flip,
+    FlipHorizontal,
+    FlipVertical,
     ThemeChange(bool),
     TextChange(String),
     SizeOption(SizeOption),
@@ -60,7 +61,8 @@ struct App {
     check: bool,
     toggle: bool,
     theme: iced::Theme,
-    flip: bool,
+    flip_h: bool,
+    flip_v: bool,
     dark_mode: bool,
     text: String,
     size_option: SizeOption,
@@ -84,7 +86,8 @@ impl Application for App {
                 check: false,
                 toggle: false,
                 theme,
-                flip: false,
+                flip_h: false,
+                flip_v: false,
                 dark_mode: false,
                 text: "Text Input".into(),
                 size_option: SizeOption::Static,
@@ -125,7 +128,8 @@ impl Application for App {
                 });
                 self.title = format!("[{:.2}, {:.2}, {:.2}]", c.r, c.g, c.b);
             }
-            Message::Flip => self.flip = !self.flip,
+            Message::FlipHorizontal => self.flip_h = !self.flip_h,
+            Message::FlipVertical => self.flip_v = !self.flip_v,
             Message::ThemeChange(b) => {
                 self.dark_mode = b;
                 let primary = self.theme.palette().primary;
@@ -185,9 +189,13 @@ impl Application for App {
             click_inside: false,
         });
 
-        let r = row!(mb, horizontal_space(Length::Fill), pick_size_option)
-            .padding([2, 8])
-            .align_items(alignment::Alignment::Center);
+        let r = if self.flip_h {
+            row!(pick_size_option, horizontal_space(Length::Fill), mb,)
+        } else {
+            row!(mb, horizontal_space(Length::Fill), pick_size_option)
+        }
+        .padding([2, 8])
+        .align_items(alignment::Alignment::Center);
 
         let top_bar_style: fn(&iced::Theme) -> container::Appearance =
             |_theme| container::Appearance {
@@ -205,7 +213,7 @@ impl Application for App {
             .height(Length::Fill)
             .style(back_style);
 
-        let c = if self.flip {
+        let c = if self.flip_v {
             col![back, top_bar,]
         } else {
             col![top_bar, back,]
@@ -526,10 +534,16 @@ fn menu_3<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
         debug_button("Controls"),
         vec![
             MenuTree::new(
-                labeled_button("Flip", Message::Flip)
+                labeled_button("Flip Horizontal", Message::FlipHorizontal)
                     .width(Length::Fill)
                     .height(Length::Fill),
             ),
+            MenuTree::new(
+                labeled_button("Flip Vertical", Message::FlipVertical)
+                    .width(Length::Fill)
+                    .height(Length::Fill),
+            ),
+            separator(),
             MenuTree::new(
                 row![toggler(
                     Some("Dark Mode".into()),

--- a/src/native/menu/menu_bar.rs
+++ b/src/native/menu/menu_bar.rs
@@ -1,6 +1,8 @@
 //! A widget that handles menu trees
 
-use super::menu_inner::{CloseCondition, ItemHeight, ItemWidth, Menu, MenuState, PathHighlight};
+use super::menu_inner::{
+    CloseCondition, Direction, ItemHeight, ItemWidth, Menu, MenuState, PathHighlight,
+};
 use super::menu_tree::MenuTree;
 use crate::style::menu_bar::StyleSheet;
 use iced_native::widget::{tree, Tree};
@@ -14,6 +16,8 @@ pub(super) struct MenuBarState {
     pub(super) cursor: Point,
     pub(super) open: bool,
     pub(super) active_root: Option<usize>,
+    pub(super) horizontal_direction: Direction,
+    pub(super) vertical_direction: Direction,
     pub(super) menu_states: Vec<MenuState>,
 }
 impl MenuBarState {
@@ -37,6 +41,8 @@ impl Default for MenuBarState {
             cursor: Point::new(-0.5, -0.5),
             open: false,
             active_root: None,
+            horizontal_direction: Direction::Positive,
+            vertical_direction: Direction::Positive,
             menu_states: Vec::new(),
         }
     }

--- a/src/native/menu/menu_inner.rs
+++ b/src/native/menu/menu_inner.rs
@@ -59,6 +59,132 @@ pub enum PathHighlight {
     MenuActive,
 }
 
+/// X+ goes right and Y+ goes down, vice versa
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Direction {
+    Positive,
+    Negative,
+}
+
+/// Adaptive open direction
+#[derive(Debug)]
+struct Aod {
+    horizontal: bool,
+    vertical: bool,
+
+    horizontal_overlap: bool,
+    vertical_overlap: bool,
+
+    horizontal_direction: Direction,
+    vertical_direction: Direction,
+}
+impl Aod {
+    fn adaptive(
+        parent_pos: f32,
+        parent_size: f32,
+        child_size: f32,
+        max_size: f32,
+        on: bool,
+        overlap: bool,
+        direction: Direction,
+    ) -> f32 {
+        /*
+        Imagine there're two sticks, parent and child
+        parent: o-----o
+        child:  o----------o
+
+        Now we align the child to the parent in one dimension
+        There are 4 possibilities:
+
+        1. to the right
+                    o-----oo----------o
+
+        2. to the right but allow overlaping
+                    o-----o
+                    o----------o
+
+        3. to the left
+        o----------oo-----o
+
+        4. to the left but allow overlaping
+                    o-----o
+               o----------o
+
+        The child goes to the default direction by default,
+        if the space on the default direction runs out it goes to the the other,
+        whether to use overlap is the caller's decision
+
+        This can be applied to any direction
+        */
+
+        match direction {
+            Direction::Positive => {
+                let space_negative = parent_pos;
+                let space_positive = max_size - parent_pos - parent_size;
+
+                if overlap {
+                    let overshoot = child_size - parent_size;
+                    if on && space_negative > space_positive && overshoot > space_positive {
+                        parent_pos - overshoot
+                    } else {
+                        parent_pos
+                    }
+                } else {
+                    let overshoot = child_size;
+                    if on && space_negative > space_positive && overshoot > space_positive {
+                        parent_pos - overshoot
+                    } else {
+                        parent_pos + parent_size
+                    }
+                }
+            }
+            Direction::Negative => {
+                let space_positive = parent_pos;
+                let space_negative = max_size - parent_pos - parent_size;
+
+                if overlap {
+                    let overshoot = child_size - parent_size;
+                    if on && space_negative > space_positive && overshoot > space_positive {
+                        parent_pos
+                    } else {
+                        parent_pos - overshoot
+                    }
+                } else {
+                    let overshoot = child_size;
+                    if on && space_negative > space_positive && overshoot > space_positive {
+                        parent_pos + parent_size
+                    } else {
+                        parent_pos - overshoot
+                    }
+                }
+            }
+        }
+    }
+
+    fn point(&self, parent_bounds: Rectangle, children_size: Size, bounds: Size) -> Point {
+        let x = Self::adaptive(
+            parent_bounds.x,
+            parent_bounds.width,
+            children_size.width,
+            bounds.width,
+            self.horizontal,
+            self.horizontal_overlap,
+            self.horizontal_direction,
+        );
+        let y = Self::adaptive(
+            parent_bounds.y,
+            parent_bounds.height,
+            children_size.height,
+            bounds.height,
+            self.vertical,
+            self.vertical_overlap,
+            self.vertical_direction,
+        );
+
+        [x, y].into()
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct MenuSlice {
     start_index: usize,
@@ -79,7 +205,7 @@ impl MenuBounds {
         item_width: ItemWidth,
         item_height: ItemHeight,
         viewport: Size,
-        aod_settings: [bool; 4],
+        aod: Aod,
         bounds_expand: u16,
         parent_bounds: Rectangle,
     ) -> Self
@@ -87,8 +213,7 @@ impl MenuBounds {
         Renderer: renderer::Renderer,
     {
         let children_size = get_children_size(menu_tree, item_width, item_height);
-        let children_position =
-            adaptive_open_direction(parent_bounds, children_size, viewport, aod_settings);
+        let children_position = aod.point(parent_bounds, children_size, viewport);
         let children_bounds = Rectangle::new(children_position, children_size);
         let child_positions = get_child_positions(menu_tree, item_height);
         let check_bounds = pad_rectangle(children_bounds, [bounds_expand; 4].into());
@@ -390,6 +515,13 @@ where
                     PathHighlight::MenuActive => i < state.menu_states.len() - 1,
                 });
 
+                // react only to the last menu
+                let cursor_position = if i == state.menu_states.len() - 1 {
+                    cursor_position
+                } else {
+                    [-1.0; 2].into()
+                };
+
                 let draw_menu = |r: &mut Renderer| {
                     // calc slice
                     let slice = ms.slice(layout.bounds().size(), self.item_height, menu_root);
@@ -488,12 +620,30 @@ fn init_root_menu<Message, Renderer>(
         }
 
         if root_bounds.contains(position) {
+            let view_center = viewport.width * 0.5;
+            let rb_center = root_bounds.center_x();
+
+            state.horizontal_direction = if rb_center > view_center {
+                Direction::Negative
+            } else {
+                Direction::Positive
+            };
+
+            let aod = Aod {
+                horizontal: true,
+                vertical: true,
+                horizontal_overlap: true,
+                vertical_overlap: false,
+                horizontal_direction: state.horizontal_direction,
+                vertical_direction: state.vertical_direction,
+            };
+
             let menu_bounds = MenuBounds::new(
                 mt,
                 menu.item_width,
                 menu.item_height,
                 viewport,
-                [false, true, true, false],
+                aod,
                 menu.bounds_expand,
                 root_bounds,
             );
@@ -616,8 +766,10 @@ where
         for i in (0..state.menu_states.len()).rev() {
             let mb = &state.menu_states[i].menu_bounds;
 
-            if (mb.parent_bounds.contains(position) || mb.check_bounds.contains(position))
-                && prev_bounds.iter().all(|pvb| !pvb.contains(position))
+            if mb.parent_bounds.contains(position)
+                || mb.children_bounds.contains(position)
+                || (mb.check_bounds.contains(position)
+                    && prev_bounds.iter().all(|pvb| !pvb.contains(position)))
             {
                 break;
             }
@@ -629,6 +781,7 @@ where
             let mb = &state.menu_states[i].menu_bounds;
 
             if mb.parent_bounds.contains(position)
+                || mb.children_bounds.contains(position)
                 || prev_bounds.iter().all(|pvb| !pvb.contains(position))
             {
                 break;
@@ -661,12 +814,11 @@ where
 
     let last_menu_bounds = &last_menu_state.menu_bounds;
     let last_parent_bounds = last_menu_bounds.parent_bounds;
-    let last_child_bounds = last_menu_bounds.children_bounds;
-    let last_check_bounds = last_menu_bounds.check_bounds;
+    let last_children_bounds = last_menu_bounds.children_bounds;
 
     if last_parent_bounds.contains(position)
     // cursor is in the parent part
-    || !last_check_bounds.contains(position)
+    || !last_children_bounds.contains(position)
     // cursor is outside
     {
         last_menu_state.index = None;
@@ -675,8 +827,8 @@ where
     // cursor is in the children part
 
     // calc new index
-    let height_diff = (position.y - (last_child_bounds.y + last_menu_state.scroll_offset))
-        .clamp(0.0, last_child_bounds.height - 0.001);
+    let height_diff = (position.y - (last_children_bounds.y + last_menu_state.scroll_offset))
+        .clamp(0.0, last_children_bounds.height - 0.001);
 
     let active_menu_root = &menu.menu_roots[active_root];
 
@@ -710,7 +862,6 @@ where
 
     // add new menu if the new item is a menu
     if !item.children.is_empty() {
-        // get new item bounds
         let item_position = Point::new(
             0.0,
             last_menu_bounds.child_positions[new_index] + last_menu_state.scroll_offset,
@@ -724,6 +875,15 @@ where
         let item_bounds = Rectangle::new(item_position, item_size)
             + (last_menu_bounds.children_bounds.position() - Point::ORIGIN);
 
+        let aod = Aod {
+            horizontal: true,
+            vertical: true,
+            horizontal_overlap: false,
+            vertical_overlap: true,
+            horizontal_direction: state.horizontal_direction,
+            vertical_direction: state.vertical_direction,
+        };
+
         state.menu_states.push(MenuState {
             index: None,
             scroll_offset: 0.0,
@@ -732,7 +892,7 @@ where
                 menu.item_width,
                 menu.item_height,
                 viewport,
-                [true, true, false, true],
+                aod,
                 menu.bounds_expand,
                 item_bounds,
             ),
@@ -740,83 +900,6 @@ where
     }
 
     Captured
-}
-
-fn adaptive_open_direction(
-    parent_bounds: Rectangle,
-    children_size: Size,
-    bounds: Size,
-    setttings: [bool; 4],
-) -> Point {
-    /*
-    Imagine there're two sticks, parent and child
-    parent: o-----o
-    child:  o----------o
-
-    Now we align the child to the parent in one dimension
-    There are 4 possibilities:
-
-    1. to the right
-                o-----oo----------o
-
-    2. to the right but allow overlaping
-                o-----o
-                o----------o
-
-    3. to the left
-    o----------oo-----o
-
-    4. to the left but allow overlaping
-                o-----o
-           o----------o
-
-    The child goes to the right by default, if the right space runs out
-    it goes to the left, whether to use overlap is the caller's decision
-
-    This can be applied to any direction
-    */
-
-    let [horizontal, vertical, horizontal_overlap, vertical_overlap] = setttings;
-
-    let calc_adaptive = |parent_pos, parent_size, child_size, max_size, on, overlap| {
-        if on {
-            let space_left = parent_pos;
-            let space_right = max_size - parent_pos - parent_size;
-
-            if space_left > space_right && child_size > space_right {
-                return if overlap {
-                    parent_pos - child_size + parent_size
-                } else {
-                    parent_pos - child_size
-                };
-            }
-        }
-
-        if overlap {
-            parent_pos
-        } else {
-            parent_pos + parent_size
-        }
-    };
-
-    let x = calc_adaptive(
-        parent_bounds.x,
-        parent_bounds.width,
-        children_size.width,
-        bounds.width,
-        horizontal,
-        horizontal_overlap,
-    );
-    let y = calc_adaptive(
-        parent_bounds.y,
-        parent_bounds.height,
-        children_size.height,
-        bounds.height,
-        vertical,
-        vertical_overlap,
-    );
-
-    [x, y].into()
 }
 
 fn process_scroll_events<Message, Renderer>(


### PR DESCRIPTION
Make horizontal direction of the root menu adaptive to it's position in the viewport

previous
<img width="400" alt="prev_a" title="Previous" src="https://user-images.githubusercontent.com/49757619/223624092-c610e5ba-3499-409b-8dec-7205751819e9.png">

after
<img width="400" alt="after_a" src="https://user-images.githubusercontent.com/49757619/223624103-63831264-b388-4618-8626-3a30ea53f326.png">

The submenus will follow the root direction so that they're less heaped-up

previous
<img width="400" alt="prev_b" src="https://user-images.githubusercontent.com/49757619/223624940-10d92905-5129-43fb-849d-dead174cdb47.png">

after
<img width="400" alt="after_b" src="https://user-images.githubusercontent.com/49757619/223624947-6292bfac-825f-4093-bc7f-9ab87ea7f8ab.png">
