### PR TITLE
feat: dark style for tabs

### DIFF
--- a/examples/tabs/src/settings.rs
+++ b/examples/tabs/src/settings.rs
@@ -103,7 +103,7 @@ impl Tab for SettingsTab {
                 ))
                 .push(Text::new("TabBar color:").size(20))
                 .push(
-                    (0..5).fold(Column::new().padding(10).spacing(10), |column, id| {
+                    (0..6).fold(Column::new().padding(10).spacing(10), |column, id| {
                         column.push(
                             Radio::new(
                                 predefined_style(id),
@@ -125,10 +125,11 @@ impl Tab for SettingsTab {
 fn predefined_style(index: usize) -> TabBarStyles {
     match index {
         0 => TabBarStyles::Default,
-        1 => TabBarStyles::Red,
-        2 => TabBarStyles::Blue,
-        3 => TabBarStyles::Green,
-        4 => TabBarStyles::Purple,
+        1 => TabBarStyles::Dark,
+        2 => TabBarStyles::Red,
+        3 => TabBarStyles::Blue,
+        4 => TabBarStyles::Green,
+        5 => TabBarStyles::Purple,
         _ => TabBarStyles::Default,
     }
 }

--- a/src/style/tab_bar.rs
+++ b/src/style/tab_bar.rs
@@ -74,6 +74,7 @@ impl Default for Appearance {
 pub enum TabBarStyles {
     #[default]
     Default,
+    Dark,
     Red,
     Blue,
     Green,
@@ -84,6 +85,7 @@ impl From<TabBarStyles> for String {
     fn from(style: TabBarStyles) -> Self {
         Self::from(match style {
             TabBarStyles::Default => "Default",
+            TabBarStyles::Dark => "Dark",
             TabBarStyles::Red => "Red",
             TabBarStyles::Blue => "Blue",
             TabBarStyles::Green => "Green",
@@ -105,6 +107,16 @@ impl StyleSheet for Theme {
                 } else {
                     Background::Color([0.87, 0.87, 0.87].into())
                 };
+            }
+            TabBarStyles::Dark => {
+                appearance.tab_label_background = if is_active {
+                    Background::Color([0.1, 0.1, 0.1].into())
+                } else {
+                    Background::Color([0.13, 0.13, 0.13].into())
+                };
+                appearance.tab_label_border_color = [0.3, 0.3, 0.3].into();
+                appearance.icon_color = Color::WHITE;
+                appearance.text_color = Color::WHITE;
             }
             TabBarStyles::Red => {
                 let text_color = if is_active {
@@ -172,6 +184,10 @@ impl StyleSheet for Theme {
         match style {
             TabBarStyles::Default => Appearance {
                 tab_label_background: Background::Color([0.9, 0.9, 0.9].into()),
+                ..self.active(style, is_active)
+            },
+            TabBarStyles::Dark => Appearance {
+                tab_label_background: Background::Color([0.1, 0.1, 0.1].into()),
                 ..self.active(style, is_active)
             },
             TabBarStyles::Red => Appearance {


### PR DESCRIPTION
Fix #125 

The colors are exactly the reverse of those in the default (light) style.