### PR TITLE
Remove unnecessary `Clone` requirement on FloatingElement's `Message`

### DIFF
--- a/src/native/floating_element.rs
+++ b/src/native/floating_element.rs
@@ -43,7 +43,6 @@ use super::overlay::floating_element::FloatingElementOverlay;
 pub struct FloatingElement<'a, B, Message, Renderer>
 where
     B: Fn() -> Element<'a, Message, Renderer>,
-    Message: Clone,
     Renderer: iced_native::Renderer,
 {
     /// The anchor of the element.
@@ -61,7 +60,6 @@ where
 impl<'a, B, Message, Renderer> FloatingElement<'a, B, Message, Renderer>
 where
     B: Fn() -> Element<'a, Message, Renderer>,
-    Message: Clone,
     Renderer: iced_native::Renderer,
 {
     /// Creates a new [`FloatingElement`](FloatingElement) over some content,
@@ -114,7 +112,7 @@ impl<'a, B, Message, Renderer> Widget<Message, Renderer>
     for FloatingElement<'a, B, Message, Renderer>
 where
     B: Fn() -> Element<'a, Message, Renderer>,
-    Message: 'a + Clone,
+    Message: 'a,
     Renderer: 'a + iced_native::Renderer,
 {
     fn children(&self) -> Vec<iced_native::widget::Tree> {
@@ -260,7 +258,7 @@ impl<'a, B, Message, Renderer> From<FloatingElement<'a, B, Message, Renderer>>
     for Element<'a, Message, Renderer>
 where
     B: 'a + Fn() -> Element<'a, Message, Renderer>,
-    Message: 'a + Clone,
+    Message: 'a,
     Renderer: 'a + iced_native::Renderer,
 {
     fn from(floating_element: FloatingElement<'a, B, Message, Renderer>) -> Self {

--- a/src/native/overlay/floating_element.rs
+++ b/src/native/overlay/floating_element.rs
@@ -9,7 +9,7 @@ use crate::native::floating_element::{Anchor, Offset};
 /// The internal overlay of a [`FloatingElement`](crate::FloatingElement) for
 /// rendering a [`Element`](iced_native::Element) as an overlay.
 #[allow(missing_debug_implementations)]
-pub struct FloatingElementOverlay<'a, Message: Clone, Renderer: iced_native::Renderer> {
+pub struct FloatingElementOverlay<'a, Message, Renderer: iced_native::Renderer> {
     /// The state of the element.
     state: &'a mut Tree,
     /// The floating element
@@ -22,7 +22,7 @@ pub struct FloatingElementOverlay<'a, Message: Clone, Renderer: iced_native::Ren
 
 impl<'a, Message, Renderer> FloatingElementOverlay<'a, Message, Renderer>
 where
-    Message: Clone + 'a,
+    Message: 'a,
     Renderer: iced_native::Renderer + 'a,
 {
     /// Creates a new [`FloatingElementOverlay`] containing the given
@@ -51,7 +51,7 @@ where
 impl<'a, Message, Renderer> iced_native::Overlay<Message, Renderer>
     for FloatingElementOverlay<'a, Message, Renderer>
 where
-    Message: Clone + 'a,
+    Message: 'a,
     Renderer: iced_native::Renderer + 'a,
 {
     fn layout(


### PR DESCRIPTION
Removing this seemingly unnecessary `Clone` attribute allows for `Message`s holding one usage not `Clone` attributes.
Such as a unique handle to a connection for example, or a `channel::Sender`.