### PR TITLE
Remove nightly version for clippy and format checks 

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,13 +3,10 @@ on: [push, pull_request]
 jobs:
   all:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, nightly]
     steps:
       - uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
           components: clippy
       - uses: actions/checkout@master
       - name: Lint with clippy

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,13 +3,10 @@ on: [push, pull_request]
 jobs:
   all:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [stable, nightly]
     steps:
       - uses: hecrj/setup-rust-action@v1
         with:
-          rust-version: ${{ matrix.rust }}
+          rust-version: stable
           components: rustfmt
       - uses: actions/checkout@master
       - name: Check format


### PR DESCRIPTION
`clippy` and `rustfmt` checks for `nightly` are really unstable, so better to use only the `stable` version