### PR TITLE
Transform clippy warnings into errors

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -10,4 +10,4 @@ jobs:
           components: clippy
       - uses: actions/checkout@master
       - name: Lint with clippy
-        run: cargo clippy --all
+        run: cargo clippy --all -- -D warnings --verbose


### PR DESCRIPTION
This PR transforms `clippy` warnings into errors. This choice allows to have a better maintainability of the code.