### PR TITLE
Menu dynamic item height

### DIFF
--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -13,7 +13,7 @@ pub fn main() -> iced::Result {
     App::run(iced::Settings {
         default_text_size: 15.0,
         window: iced::window::Settings {
-            size: (800, 500),
+            size: (1000, 500),
             // position: iced::window::Position::Default,
             ..Default::default()
         },
@@ -25,9 +25,14 @@ pub fn main() -> iced::Result {
 enum SizeOption {
     Uniform,
     Static,
+    DynamicHeight,
 }
 impl SizeOption {
-    const ALL: [SizeOption; 2] = [SizeOption::Uniform, SizeOption::Static];
+    const ALL: [SizeOption; 3] = [
+        SizeOption::Uniform,
+        SizeOption::Static,
+        SizeOption::DynamicHeight,
+    ];
 }
 impl std::fmt::Display for SizeOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -37,6 +42,7 @@ impl std::fmt::Display for SizeOption {
             match self {
                 Self::Uniform => "Uniform",
                 Self::Static => "Static",
+                Self::DynamicHeight => "DynamicHeight",
             }
         )
     }
@@ -91,7 +97,7 @@ impl Application for App {
                 flip_v: false,
                 dark_mode: false,
                 text: "Text Input".into(),
-                size_option: SizeOption::Static,
+                size_option: SizeOption::DynamicHeight,
             },
             iced::Command::none(),
         )
@@ -177,6 +183,15 @@ impl Application for App {
                 menu_3(self),
                 menu_4(self),
                 menu_5(self),
+            )
+            .item_width(ItemWidth::Static(180))
+            .item_height(ItemHeight::Static(25)),
+            SizeOption::DynamicHeight => menu_bar!(
+                menu_1(self),
+                menu_2(self),
+                menu_3(self),
+                menu_4(self),
+                menu_6(self),
             )
             .item_width(ItemWidth::Static(180))
             .item_height(ItemHeight::Static(25)),
@@ -274,6 +289,14 @@ fn debug_button<'a>(label: &str) -> button::Button<'a, Message, iced::Renderer> 
 
 fn debug_item<'a>(label: &str) -> MenuTree<'a, Message, iced::Renderer> {
     menu_tree!(debug_button(label).width(Length::Fill).height(Length::Fill))
+}
+
+fn debug_item2<'a>(label: &str) -> MenuTree<'a, Message, iced::Renderer> {
+    menu_tree!(debug_button(label).width(Length::Fill).height(Length::Shrink))
+}
+
+fn debug_item3<'a>(label: &str, h: f32) -> MenuTree<'a, Message, iced::Renderer> {
+    menu_tree!(debug_button(label).width(Length::Fill).height(Length::Fixed(h)))
 }
 
 fn color_item<'a>(color: impl Into<Color>) -> MenuTree<'a, Message, iced::Renderer> {
@@ -720,6 +743,51 @@ fn menu_5<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     let root = menu_tree(
         debug_button("Static"),
         vec![labeled_separator("Primary"), sliders],
+    )
+    .width(slider_width * slider_count + (slider_count - 1) * spacing);
+
+    root
+}
+
+fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
+    let slider_count = 3;
+    let slider_width = 30;
+    let spacing = 4;
+
+    let [r, g, b, _] = app.theme.palette().primary.into_rgba8();
+
+    let sliders = menu_tree!(row![
+        vertical_slider(0..=255, r, move |x| Message::ColorChange(Color::from_rgb8(
+            x, g, b
+        )))
+        .width(30),
+        vertical_slider(0..=255, g, move |x| Message::ColorChange(Color::from_rgb8(
+            r, x, b
+        )))
+        .width(30),
+        vertical_slider(0..=255, b, move |x| Message::ColorChange(Color::from_rgb8(
+            r, g, x
+        )))
+        .width(30),
+    ]
+    .spacing(4))
+    .height(100);
+
+    let root = menu_tree(
+        debug_button("Dynamic Height"),
+        vec![
+            labeled_separator("Primary"),
+            sliders,
+            debug_item2("AABB")
+                // .height(80)
+                ,
+            debug_item3("CCDD", 50.0)
+                // .height(60)
+                ,
+            debug_item2("EEFF")
+                // .height(50)
+                ,
+        ],
     )
     .width(slider_width * slider_count + (slider_count - 1) * spacing);
 

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -175,7 +175,7 @@ impl Application for App {
             SizeOption::Uniform => {
                 menu_bar!(menu_1(self), menu_2(self), menu_3(self), menu_4(self))
                     .item_width(ItemWidth::Uniform(180))
-                    .item_height(ItemHeight::Uniform(25))
+                    .item_height(ItemHeight::Uniform(27))
             }
             SizeOption::Static => menu_bar!(
                 menu_1(self),
@@ -185,16 +185,16 @@ impl Application for App {
                 menu_5(self),
             )
             .item_width(ItemWidth::Static(180))
-            .item_height(ItemHeight::Static(25)),
+            .item_height(ItemHeight::Static(35)),
             SizeOption::DynamicHeight => menu_bar!(
                 menu_1(self),
                 menu_2(self),
                 menu_3(self),
-                menu_44(self),
-                menu_55(self),
+                menu_4(self),
+                menu_6(self),
             )
             .item_width(ItemWidth::Static(180))
-            .item_height(ItemHeight::Dynamic(32)),
+            .item_height(ItemHeight::Dynamic(35)),
         }
         .spacing(4.0)
         .bounds_expand(30)
@@ -346,46 +346,6 @@ fn debug_sub_menu<'a>(
     children: Vec<MenuTree<'a, Message, iced::Renderer>>,
 ) -> MenuTree<'a, Message, iced::Renderer> {
     sub_menu(label, Message::Debug(label.into()), children)
-}
-
-fn sub_menu2<'a>(
-    label: &str,
-    msg: Message,
-    children: Vec<MenuTree<'a, Message, iced::Renderer>>,
-) -> MenuTree<'a, Message, iced::Renderer> {
-    let handle = svg::Handle::from_path(format!(
-        "{}/caret-right-fill.svg",
-        env!("CARGO_MANIFEST_DIR")
-    ));
-    let arrow = svg(handle)
-        .width(Length::Shrink)
-        .style(theme::Svg::custom_fn(|theme| svg::Appearance {
-            color: Some(theme.extended_palette().background.base.text),
-        }));
-
-    menu_tree(
-        base_button(
-            row![
-                text(label)
-                    .width(Length::Fill)
-                    .height(Length::Shrink)
-                    .vertical_alignment(alignment::Vertical::Center),
-                arrow
-            ]
-            .align_items(iced::Alignment::Center),
-            msg,
-        )
-        .width(Length::Fill)
-        .height(Length::Shrink),
-        children,
-    )
-}
-
-fn debug_sub_menu2<'a>(
-    label: &str,
-    children: Vec<MenuTree<'a, Message, iced::Renderer>>,
-) -> MenuTree<'a, Message, iced::Renderer> {
-    sub_menu2(label, Message::Debug(label.into()), children)
 }
 
 fn separator<'a>() -> MenuTree<'a, Message, iced::Renderer> {
@@ -761,146 +721,6 @@ fn menu_4<'a>(_app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     root
 }
 
-fn menu_44<'a>(_app: &App) -> MenuTree<'a, Message, iced::Renderer> {
-    let dekjdaud = debug_sub_menu2(
-        "dekjdaud",
-        vec![
-            debug_item2("ajrs"),
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"),
-            debug_item2("ajrs"),
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"),
-        ],
-    );
-
-    let luyortp = debug_sub_menu2(
-        "luyortp",
-        vec![
-            debug_item2("ajrs"), // 0
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 13
-        ],
-    );
-
-    let jcsu = debug_sub_menu2(
-        "jcsu",
-        vec![
-            debug_item2("ajrs"), // 0
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            luyortp, // 11
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 13
-        ],
-    );
-
-    let root = menu_tree(
-        debug_button("Scroll"),
-        vec![
-            debug_item2("ajrs"), // 0
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            jcsu, // 9
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 13
-            debug_item2("ajrs"), // 14
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 27
-            debug_item2("ajrs"), // 28
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            dekjdaud,
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"),
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 41
-            debug_item2("ajrs"), // 42
-            debug_item2("bsdfho"),
-            debug_item2("clkjhbf"),
-            debug_item2("dekjdaud"),
-            debug_item2("ecsh"),
-            debug_item2("fweiu"),
-            debug_item2("giwe"),
-            debug_item2("heruyv"),
-            debug_item2("isabe"),
-            debug_item2("jcsu"),
-            debug_item2("kaljkahd"), // 52
-            debug_item2("luyortp"),
-            debug_item2("mmdyrc"),
-            debug_item2("nquc"), // 55
-        ],
-    );
-
-    root
-}
-
 fn menu_5<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     let slider_count = 3;
     let slider_width = 30;
@@ -934,7 +754,7 @@ fn menu_5<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     root
 }
 
-fn menu_55<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
+fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     let slider_count = 3;
     let slider_width = 30;
     let spacing = 4;
@@ -945,30 +765,29 @@ fn menu_55<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
         vertical_slider(0..=255, r, move |x| Message::ColorChange(Color::from_rgb8(
             x, g, b
         )))
-        .height(80)
         .width(30),
         vertical_slider(0..=255, g, move |x| Message::ColorChange(Color::from_rgb8(
             r, x, b
         )))
-        .height(80)
         .width(30),
         vertical_slider(0..=255, b, move |x| Message::ColorChange(Color::from_rgb8(
             r, g, x
         )))
-        .height(80)
         .width(30),
     ]
-    .spacing(4))
-    .height(100);
+    .spacing(4)
+    .height(100));
 
     let root = menu_tree(
         debug_button("Dynamic Height"),
         vec![
             labeled_separator("Primary"),
             sliders,
-            debug_item2("AABB"),       // .height(80)
-            debug_item3("CCDD", 50.0), // .height(60)
-            debug_item2("EEFF"),       // .height(50)
+            debug_item2("AABB"),
+            debug_item3("CCDD", 50.0),
+            debug_item2("EEFF"),
+            debug_item("GGHH").height(100),
+            debug_item2("IIJJ"),
         ],
     )
     .width(slider_width * slider_count + (slider_count - 1) * spacing);

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -190,11 +190,11 @@ impl Application for App {
                 menu_1(self),
                 menu_2(self),
                 menu_3(self),
-                menu_4(self),
-                menu_6(self),
+                menu_44(self),
+                menu_55(self),
             )
             .item_width(ItemWidth::Static(180))
-            .item_height(ItemHeight::Static(25)),
+            .item_height(ItemHeight::Dynamic(32)),
         }
         .spacing(4.0)
         .bounds_expand(30)
@@ -331,7 +331,8 @@ fn sub_menu<'a>(
                     .height(Length::Fill)
                     .vertical_alignment(alignment::Vertical::Center),
                 arrow
-            ],
+            ]
+            .align_items(iced::Alignment::Center),
             msg,
         )
         .width(Length::Fill)
@@ -345,6 +346,46 @@ fn debug_sub_menu<'a>(
     children: Vec<MenuTree<'a, Message, iced::Renderer>>,
 ) -> MenuTree<'a, Message, iced::Renderer> {
     sub_menu(label, Message::Debug(label.into()), children)
+}
+
+fn sub_menu2<'a>(
+    label: &str,
+    msg: Message,
+    children: Vec<MenuTree<'a, Message, iced::Renderer>>,
+) -> MenuTree<'a, Message, iced::Renderer> {
+    let handle = svg::Handle::from_path(format!(
+        "{}/caret-right-fill.svg",
+        env!("CARGO_MANIFEST_DIR")
+    ));
+    let arrow = svg(handle)
+        .width(Length::Shrink)
+        .style(theme::Svg::custom_fn(|theme| svg::Appearance {
+            color: Some(theme.extended_palette().background.base.text),
+        }));
+
+    menu_tree(
+        base_button(
+            row![
+                text(label)
+                    .width(Length::Fill)
+                    .height(Length::Shrink)
+                    .vertical_alignment(alignment::Vertical::Center),
+                arrow
+            ]
+            .align_items(iced::Alignment::Center),
+            msg,
+        )
+        .width(Length::Fill)
+        .height(Length::Shrink),
+        children,
+    )
+}
+
+fn debug_sub_menu2<'a>(
+    label: &str,
+    children: Vec<MenuTree<'a, Message, iced::Renderer>>,
+) -> MenuTree<'a, Message, iced::Renderer> {
+    sub_menu2(label, Message::Debug(label.into()), children)
 }
 
 fn separator<'a>() -> MenuTree<'a, Message, iced::Renderer> {
@@ -720,6 +761,146 @@ fn menu_4<'a>(_app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     root
 }
 
+fn menu_44<'a>(_app: &App) -> MenuTree<'a, Message, iced::Renderer> {
+    let dekjdaud = debug_sub_menu2(
+        "dekjdaud",
+        vec![
+            debug_item2("ajrs"),
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"),
+            debug_item2("ajrs"),
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"),
+        ],
+    );
+
+    let luyortp = debug_sub_menu2(
+        "luyortp",
+        vec![
+            debug_item2("ajrs"), // 0
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 13
+        ],
+    );
+
+    let jcsu = debug_sub_menu2(
+        "jcsu",
+        vec![
+            debug_item2("ajrs"), // 0
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            luyortp, // 11
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 13
+        ],
+    );
+
+    let root = menu_tree(
+        debug_button("Scroll"),
+        vec![
+            debug_item2("ajrs"), // 0
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            jcsu, // 9
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 13
+            debug_item2("ajrs"), // 14
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 27
+            debug_item2("ajrs"), // 28
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            dekjdaud,
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"),
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 41
+            debug_item2("ajrs"), // 42
+            debug_item2("bsdfho"),
+            debug_item2("clkjhbf"),
+            debug_item2("dekjdaud"),
+            debug_item2("ecsh"),
+            debug_item2("fweiu"),
+            debug_item2("giwe"),
+            debug_item2("heruyv"),
+            debug_item2("isabe"),
+            debug_item2("jcsu"),
+            debug_item2("kaljkahd"), // 52
+            debug_item2("luyortp"),
+            debug_item2("mmdyrc"),
+            debug_item2("nquc"), // 55
+        ],
+    );
+
+    root
+}
+
 fn menu_5<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     let slider_count = 3;
     let slider_width = 30;
@@ -753,7 +934,7 @@ fn menu_5<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     root
 }
 
-fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
+fn menu_55<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
     let slider_count = 3;
     let slider_width = 30;
     let spacing = 4;
@@ -764,14 +945,17 @@ fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
         vertical_slider(0..=255, r, move |x| Message::ColorChange(Color::from_rgb8(
             x, g, b
         )))
+        .height(80)
         .width(30),
         vertical_slider(0..=255, g, move |x| Message::ColorChange(Color::from_rgb8(
             r, x, b
         )))
+        .height(80)
         .width(30),
         vertical_slider(0..=255, b, move |x| Message::ColorChange(Color::from_rgb8(
             r, g, x
         )))
+        .height(80)
         .width(30),
     ]
     .spacing(4))
@@ -782,9 +966,9 @@ fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
         vec![
             labeled_separator("Primary"),
             sliders,
-            debug_item2("AABB"), // .height(80)
+            debug_item2("AABB"),       // .height(80)
             debug_item3("CCDD", 50.0), // .height(60)
-            debug_item2("EEFF"), // .height(50)
+            debug_item2("EEFF"),       // .height(50)
         ],
     )
     .width(slider_width * slider_count + (slider_count - 1) * spacing);

--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -292,11 +292,15 @@ fn debug_item<'a>(label: &str) -> MenuTree<'a, Message, iced::Renderer> {
 }
 
 fn debug_item2<'a>(label: &str) -> MenuTree<'a, Message, iced::Renderer> {
-    menu_tree!(debug_button(label).width(Length::Fill).height(Length::Shrink))
+    menu_tree!(debug_button(label)
+        .width(Length::Fill)
+        .height(Length::Shrink))
 }
 
 fn debug_item3<'a>(label: &str, h: f32) -> MenuTree<'a, Message, iced::Renderer> {
-    menu_tree!(debug_button(label).width(Length::Fill).height(Length::Fixed(h)))
+    menu_tree!(debug_button(label)
+        .width(Length::Fill)
+        .height(Length::Fixed(h)))
 }
 
 fn color_item<'a>(color: impl Into<Color>) -> MenuTree<'a, Message, iced::Renderer> {
@@ -778,15 +782,9 @@ fn menu_6<'a>(app: &App) -> MenuTree<'a, Message, iced::Renderer> {
         vec![
             labeled_separator("Primary"),
             sliders,
-            debug_item2("AABB")
-                // .height(80)
-                ,
-            debug_item3("CCDD", 50.0)
-                // .height(60)
-                ,
-            debug_item2("EEFF")
-                // .height(50)
-                ,
+            debug_item2("AABB"), // .height(80)
+            debug_item3("CCDD", 50.0), // .height(60)
+            debug_item2("EEFF"), // .height(50)
         ],
     )
     .width(slider_width * slider_count + (slider_count - 1) * spacing);

--- a/src/native/menu/menu_inner.rs
+++ b/src/native/menu/menu_inner.rs
@@ -287,10 +287,12 @@ impl MenuState {
 
         let child_nodes = self.menu_bounds.child_positions[start_index..=end_index]
             .iter()
+            .zip(self.menu_bounds.child_sizes[start_index..=end_index].iter())
             .zip(menu_tree.children[start_index..=end_index].iter())
-            .map(|(cp, mt)| {
+            .map(|((cp, size), mt)| {
                 let mut position = *cp;
-                let mut size = get_item_size(mt, children_bounds.width, item_height);
+                let mut size = *size;
+                // let mut size = get_item_size(mt, children_bounds.width, item_height);
 
                 if position < lower_bound_rel && (position + size.height) > lower_bound_rel {
                     size.height = position + size.height - lower_bound_rel;
@@ -330,7 +332,8 @@ impl MenuState {
         let position = self.menu_bounds.child_positions[index];
         let limits = Limits::new(
             Size::ZERO,
-            get_item_size(menu_tree, children_bounds.width, item_height),
+            // get_item_size(menu_tree, children_bounds.width, item_height),
+            self.menu_bounds.child_sizes[index]
         );
         let parent_offset = children_bounds.position() - Point::ORIGIN;
         let mut node = menu_tree.item.as_widget().layout(renderer, &limits);
@@ -947,11 +950,13 @@ where
             0.0,
             last_menu_bounds.child_positions[new_index] + last_menu_state.scroll_offset,
         );
-        let item_size = get_item_size(
-            item,
-            last_menu_bounds.children_bounds.width,
-            menu.item_height,
-        );
+        let item_size = last_menu_bounds.child_sizes[new_index];
+        
+        // let item_size = get_item_size(
+        //     item,
+        //     last_menu_bounds.children_bounds.width,
+        //     menu.item_height,
+        // );
 
         // overlay space item bounds
         let item_bounds = Rectangle::new(item_position, item_size)
@@ -1062,21 +1067,21 @@ where
     Captured
 }
 
-fn get_item_size<Message, Renderer>(
-    menu_tree: &MenuTree<'_, Message, Renderer>,
-    width: f32,
-    item_height: ItemHeight,
-) -> Size
-where
-    Renderer: renderer::Renderer,
-{
-    let height = match item_height {
-        ItemHeight::Uniform(u) => f32::from(u),
-        ItemHeight::Static(s) => f32::from(menu_tree.height.unwrap_or(s)),
-    };
+// fn get_item_size<Message, Renderer>(
+//     menu_tree: &MenuTree<'_, Message, Renderer>,
+//     width: f32,
+//     item_height: ItemHeight,
+// ) -> Size
+// where
+//     Renderer: renderer::Renderer,
+// {
+//     let height = match item_height {
+//         ItemHeight::Uniform(u) => f32::from(u),
+//         ItemHeight::Static(s) => f32::from(menu_tree.height.unwrap_or(s)),
+//     };
 
-    Size::new(width, height)
-}
+//     Size::new(width, height)
+// }
 
 // fn get_children_size<Message, Renderer>(
 //     menu_tree: &MenuTree<'_, Message, Renderer>,
@@ -1090,7 +1095,6 @@ where
 //         ItemWidth::Uniform(u) => f32::from(u),
 //         ItemWidth::Static(s) => f32::from(menu_tree.width.unwrap_or(s)),
 //     };
-
 //     let height = match item_height {
 //         ItemHeight::Uniform(u) => f32::from(u) * (menu_tree.children.len() as f32),
 //         ItemHeight::Static(s) => menu_tree
@@ -1098,7 +1102,6 @@ where
 //             .iter()
 //             .fold(0.0, |h, mt| h + f32::from(mt.height.unwrap_or(s))),
 //     };
-
 //     Size::new(width, height)
 // }
 


### PR DESCRIPTION
Add `ItemHeight::Dynamic` #158 

Automatically chooses proper item height in these cases:
- Fixed height
- Shrink height
- Menu tree height

When none of these is the case it will fallback to the default value

