### PR TITLE
Submenu offset

### DIFF
--- a/examples/menu/src/main.rs
+++ b/examples/menu/src/main.rs
@@ -198,6 +198,8 @@ impl Application for App {
         }
         .spacing(4.0)
         .bounds_expand(30)
+        .main_offset(13)
+        .cross_offset(16)
         .path_highlight(Some(PathHighlight::MenuActive))
         .close_condition(CloseCondition {
             leave: true,

--- a/src/native/menu/menu_bar.rs
+++ b/src/native/menu/menu_bar.rs
@@ -65,6 +65,8 @@ where
     spacing: f32,
     padding: Padding,
     bounds_expand: u16,
+    main_offset: i32,
+    cross_offset: i32,
     close_condition: CloseCondition,
     item_width: ItemWidth,
     item_height: ItemHeight,
@@ -89,6 +91,8 @@ where
             spacing: 0.0,
             padding: Padding::ZERO,
             bounds_expand: 15,
+            main_offset: 0,
+            cross_offset: 0,
             close_condition: CloseCondition {
                 leave: true,
                 click_outside: true,
@@ -131,6 +135,20 @@ where
     #[must_use]
     pub fn bounds_expand(mut self, value: u16) -> Self {
         self.bounds_expand = value;
+        self
+    }
+
+    /// Moves all the menus in the vertical open direction
+    #[must_use]
+    pub fn main_offset(mut self, value: i32) -> Self {
+        self.main_offset = value;
+        self
+    }
+
+    /// Moves each menu in the horizontal open direction
+    #[must_use]
+    pub fn cross_offset(mut self, value: i32) -> Self {
+        self.cross_offset = value;
         self
     }
 
@@ -387,6 +405,8 @@ where
                 item_width: self.item_width,
                 item_height: self.item_height,
                 bar_bounds: layout.bounds(),
+                main_offset: self.main_offset,
+                cross_offset: self.cross_offset,
                 root_bounds_list: layout.children().map(|lo| lo.bounds()).collect(),
                 path_highlight: self.path_highlight,
                 style: &self.style,

--- a/src/native/menu/menu_inner.rs
+++ b/src/native/menu/menu_inner.rs
@@ -182,8 +182,13 @@ impl Aod {
         }
     }
 
-    /// Returns child position and offset position 
-    fn resolve(&self, parent_bounds: Rectangle, children_size: Size, viewport_size: Size) -> (Point, Point) {
+    /// Returns child position and offset position
+    fn resolve(
+        &self,
+        parent_bounds: Rectangle,
+        children_size: Size,
+        viewport_size: Size,
+    ) -> (Point, Point) {
         let (x, ox) = Self::adaptive(
             parent_bounds.x,
             parent_bounds.width,
@@ -261,9 +266,9 @@ impl MenuBounds {
 
         // calc offset bounds
         let delta = children_position - offset_position;
-        let offset_size = if delta.x.abs() > delta.y.abs(){
+        let offset_size = if delta.x.abs() > delta.y.abs() {
             Size::new(delta.x, children_size.height)
-        }else{
+        } else {
             Size::new(children_size.width, delta.y)
         };
         let offset_bounds = Rectangle::new(offset_position, offset_size);


### PR DESCRIPTION
Fix #150 by adding `main_offset` and `cross_offset`

`main_offset` moves all the menus in the vertical open direction

`cross_offset` moves each menu in the horizontal open direction

Before
<img width="500" alt="submenu_offset before" src="https://github.com/iced-rs/iced_aw/assets/49757619/b388db5e-bec9-42ba-8764-40bf0ed09401">
<br/>
After (main_offset = 13,  cross_offset = 16)
<img width="500" alt="submenu_offset after" src="https://github.com/iced-rs/iced_aw/assets/49757619/2b38bf70-1a73-426f-befc-0f2e1d745da3">


