### PR TITLE
Card overlays

### DIFF
--- a/src/native/card.rs
+++ b/src/native/card.rs
@@ -575,8 +575,9 @@ where
                 .zip(&mut tree.children)
                 .zip(layout.children())
                 .filter_map(|((child, state), layout)| {
-                    let first_child = layout.children().next().unwrap();
-                    child.as_widget_mut().overlay(state, first_child, renderer)
+                    layout.children().next().map(|child_layout| {
+                        child.as_widget_mut().overlay(state, child_layout, renderer)
+                    }).unwrap_or(None)
                 })
                 .collect::<Vec<_>>();
 

--- a/src/native/card.rs
+++ b/src/native/card.rs
@@ -561,29 +561,29 @@ where
     }
 
     fn overlay<'b>(
-            &'b mut self,
-            tree: &'b mut Tree,
-            layout: Layout<'_>,
-            renderer: &Renderer,
-        ) -> Option<core::overlay::Element<'b, Message, Renderer>> {
-            let mut children = vec![&mut self.head, &mut self.body];
-            if let Some(foot) = &mut self.foot {
-                children.push(foot);
-            }
-            let children = children
-                .into_iter()
-                .zip(&mut tree.children)
-                .zip(layout.children())
-                .filter_map(|((child, state), layout)| {
-                    layout.children().next().and_then(|child_layout| {
-                        child.as_widget_mut().overlay(state, child_layout, renderer)
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            (!children.is_empty()).then(|| core::overlay::Group::with_children(children).overlay())
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<core::overlay::Element<'b, Message, Renderer>> {
+        let mut children = vec![&mut self.head, &mut self.body];
+        if let Some(foot) = &mut self.foot {
+            children.push(foot);
         }
+        let children = children
+            .into_iter()
+            .zip(&mut tree.children)
+            .zip(layout.children())
+            .filter_map(|((child, state), layout)| {
+                layout.children().next().and_then(|child_layout| {
+                    child.as_widget_mut().overlay(state, child_layout, renderer)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        (!children.is_empty()).then(|| core::overlay::Group::with_children(children).overlay())
     }
+}
 
 /// Calculates the layout of the head.
 fn head_node<Message, Renderer>(

--- a/src/native/card.rs
+++ b/src/native/card.rs
@@ -575,9 +575,9 @@ where
                 .zip(&mut tree.children)
                 .zip(layout.children())
                 .filter_map(|((child, state), layout)| {
-                    layout.children().next().map(|child_layout| {
+                    layout.children().next().and_then(|child_layout| {
                         child.as_widget_mut().overlay(state, child_layout, renderer)
-                    }).unwrap_or(None)
+                    })
                 })
                 .collect::<Vec<_>>();
 


### PR DESCRIPTION
Currently cards can't have overlays, which this PR implements, however a few questions remain:
- All the children have their own wrapper layout, I'm sure there's a reason for it. This means the overlay method must be called for the first child within the wrapper (the actual child layout), otherwise only the first one will be rendered (eg. Row [ PickList (this only), PickList, PickList ]). This requires either an unwrap or some kind of logic, which is, even if it's just a line, may not be necessary. Could this be a valid reason to remove the wrappers and use the child layouts direcly?
- is there a point to have overlays for the header or the footer? In my opinion only allowing the body to have overlays could be sensible, however I do have some use cases from the past where I had to use dropdown menus in the footer