### PR TITLE
Set tag for MenuBar

### DIFF
--- a/src/native/menu/menu_bar.rs
+++ b/src/native/menu/menu_bar.rs
@@ -242,6 +242,10 @@ where
         }
     }
 
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<MenuBarState>()
+    }
+
     fn state(&self) -> tree::State {
         tree::State::new(MenuBarState::default())
     }


### PR DESCRIPTION
If MenuBar replaces a different (stateless) widget in the view for an application it causes a downcast error because the state is never initialised correctly: since tag() is not implemented for it, diff() gets called instead of state()/children().