### PR TITLE
Wrap example is broken

### DIFF
--- a/examples/wrap/src/main.rs
+++ b/examples/wrap/src/main.rs
@@ -113,7 +113,7 @@ impl Sandbox for RandStrings {
         let RandStrings {
             vbuttons, hbuttons, ..
         } = self;
-        let vertcal = Container::new(
+        let vertical = Container::new(
             vbuttons
                 .iter()
                 .fold(Wrap::new_vertical(), |wrap, button| {
@@ -176,6 +176,6 @@ impl Sandbox for RandStrings {
             .align_items(iced::Alignment::Center)
             .width(iced::Length::Fixed(130.0));
 
-        Row::new().push(ctrls).push(vertcal).push(horizontal).into()
+        Row::new().push(ctrls).push(vertical).push(horizontal).into()
     }
 }

--- a/examples/wrap/src/main.rs
+++ b/examples/wrap/src/main.rs
@@ -173,8 +173,7 @@ impl Sandbox for RandStrings {
             .push(line_spacing_input)
             .push(line_minimal_length_input)
             .height(iced::Length::Shrink)
-            .align_items(iced::Alignment::Center)
-            .width(iced::Length::Fixed(130.0));
+            .align_items(iced::Alignment::Center);
 
         Row::new().push(ctrls).push(vertical).push(horizontal).into()
     }

--- a/examples/wrap/src/main.rs
+++ b/examples/wrap/src/main.rs
@@ -173,7 +173,8 @@ impl Sandbox for RandStrings {
             .push(line_spacing_input)
             .push(line_minimal_length_input)
             .height(iced::Length::Shrink)
-            .align_items(iced::Alignment::Center);
+            .align_items(iced::Alignment::Center)
+            .width(iced::Length::Fixed(130.0));
 
         Row::new().push(ctrls).push(vertcal).push(horizontal).into()
     }

--- a/examples/wrap/src/main.rs
+++ b/examples/wrap/src/main.rs
@@ -175,6 +175,10 @@ impl Sandbox for RandStrings {
             .height(iced::Length::Shrink)
             .align_items(iced::Alignment::Center);
 
-        Row::new().push(ctrls).push(vertical).push(horizontal).into()
+        Row::new()
+            .push(ctrls)
+            .push(vertical)
+            .push(horizontal)
+            .into()
     }
 }

--- a/src/native/number_input.rs
+++ b/src/native/number_input.rs
@@ -125,7 +125,7 @@ where
             on_change: Box::new(on_changed),
             style: <Renderer::Theme as number_input::StyleSheet>::Style::default(),
             font: Renderer::Font::default(),
-            width: Length::Fill,
+            width: Length::Shrink,
         }
     }
 


### PR DESCRIPTION
The `wrap` example looks like this to me:
![broke](https://github.com/iced-rs/iced_aw/assets/2229554/b593ca30-c059-4bc8-ad07-77ee3cf251dc)

Changing the controls column width from the default `iced::Length::Shrink` to either `iced::Length::Fixed(value)` or `iced::Length::FillPortion(value)` fixes the example program.