### PR TITLE
handle unavailable cursor position in TabBar

### DIFF
--- a/src/native/tab_bar.rs
+++ b/src/native/tab_bar.rs
@@ -672,16 +672,15 @@ fn draw_tab<Theme, Renderer>(
         item.expect("Graphics: Layout should have an texts layout for an IconText")
             .bounds()
     }
-    let is_mouse_over = cursor
-        .position()
-        .map_or(false, |pos| layout.bounds().contains(pos));
+
+    let bounds = layout.bounds();
+    let is_mouse_over = cursor.position().map_or(false, |pos| bounds.contains(pos));
     let style = if is_mouse_over {
         theme.hovered(style, is_selected)
     } else {
         theme.active(style, is_selected)
     };
 
-    let bounds = layout.bounds();
     let mut children = layout.children();
     let label_layout = children
         .next()

--- a/src/native/tab_bar.rs
+++ b/src/native/tab_bar.rs
@@ -672,9 +672,9 @@ fn draw_tab<Theme, Renderer>(
         item.expect("Graphics: Layout should have an texts layout for an IconText")
             .bounds()
     }
-    let is_mouse_over = layout
-        .bounds()
-        .contains(cursor.position().unwrap_or_default());
+    let is_mouse_over = cursor
+        .position()
+        .map_or(false, |pos| layout.bounds().contains(pos));
     let style = if is_mouse_over {
         theme.hovered(style, is_selected)
     } else {

--- a/src/native/tab_bar.rs
+++ b/src/native/tab_bar.rs
@@ -523,16 +523,16 @@ where
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                if layout
-                    .bounds()
-                    .contains(cursor.position().unwrap_or_default())
+                if cursor
+                    .position()
+                    .map_or(false, |pos| layout.bounds().contains(pos))
                 {
                     let tabs_map: Vec<bool> = layout
                         .children()
                         .map(|layout| {
-                            layout
-                                .bounds()
-                                .contains(cursor.position().unwrap_or_default())
+                            cursor
+                                .position()
+                                .map_or(false, |pos| layout.bounds().contains(pos))
                         })
                         .collect();
 
@@ -544,7 +544,7 @@ where
                                     let tab_layout = layout.children().nth(new_selected).expect("Native: Layout should have a tab layout at the selected index");
                                     let cross_layout = tab_layout.children().nth(1).expect("Native: Layout should have a close layout");
 
-                                    cross_layout.bounds().contains(cursor.position().unwrap_or_default())
+                                    cursor.position().map_or(false, |pos| cross_layout.bounds().contains(pos) )
                                 })
                                 .map_or_else(
                                     || (self.on_select)(self.tab_indices[new_selected].clone()),
@@ -572,9 +572,9 @@ where
         let mut mouse_interaction = mouse::Interaction::default();
 
         for layout in children {
-            let is_mouse_over = layout
-                .bounds()
-                .contains(cursor.position().unwrap_or_default());
+            let is_mouse_over = cursor
+                .position()
+                .map_or(false, |pos| layout.bounds().contains(pos));
             let new_mouse_interaction = if is_mouse_over {
                 mouse::Interaction::Pointer
             } else {
@@ -601,7 +601,7 @@ where
     ) {
         let bounds = layout.bounds();
         let children = layout.children();
-        let is_mouse_over = bounds.contains(cursor.position().unwrap_or_default());
+        let is_mouse_over = cursor.position().map_or(false, |pos| bounds.contains(pos));
         let style_sheet = if is_mouse_over {
             theme.hovered(&self.style, false)
         } else {


### PR DESCRIPTION
hover checks in TabBar handle an unavailable cursor position by using a default position.
this default position however is inside the window, resulting in a potential positive hover check if the cursor is outside the window

![2024-02-29_18-16-06_NVIDIA_Share](https://github.com/iced-rs/iced_aw/assets/40620628/1fb159c1-81b3-4517-9f1b-c19fe0b1c925) ![2024-02-29_18-16-14_tabs](https://github.com/iced-rs/iced_aw/assets/40620628/1ecd147d-16eb-490b-9be9-9804edccf7bc)
_(hovering an active tab will not show a highlight, it is actually 'hovered' in the second screenshot)_

this pull changes the bounds checks in tab_bar to treat an unavailable cursor as false

![2024-02-29_18-18-49_NVIDIA_Share](https://github.com/iced-rs/iced_aw/assets/40620628/beb34ac4-c53e-415c-9a2d-7121eee2d5d7)

i have to admit that
```rust
if cursor
    .position()
    .map_or(false, |pos| layout.bounds().contains(pos))
```
is a bit harder to read than
```rust
if layout
    .bounds()
    .contains(cursor.position().unwrap_or(Point { x: -1., y: -1. }));
```
_at least for me_

but i choose the former as
- a: im not sure if negative values are actually impossible to be returned by cursor.position()
- b: i think it more accurately represents the intention, of returning when false there is no overlap, and without a cursor position there cant be one. instead of checking an arbitrary invalid point

i also split this into 3 commits _(since i dont know what all of these functions actually do)_
- the first one addresses the "issue" i had
- the third applies the same logic to the remaining checks

at leas on desktop everything seems to still work _(in the TabBar example)_