### PR TITLE
change TabBar hovered appearance for default style

### DIFF
--- a/src/style/tab_bar.rs
+++ b/src/style/tab_bar.rs
@@ -191,11 +191,7 @@ impl StyleSheet for Theme {
         let palette = self.extended_palette();
         match style {
             TabBarStyles::Default => Appearance {
-                tab_label_background: Background::Color(if is_active {
-                    palette.background.strong.color
-                } else {
-                    palette.primary.strong.color
-                }),
+                tab_label_background: Background::Color(palette.primary.strong.color),
                 ..self.active(style, is_active)
             },
             TabBarStyles::Dark => Appearance {


### PR DESCRIPTION
im not sure if this was intentional, but hovering over an active tab will not highlight it anymore, which i find a bit odd

![2024-02-29_19-15-01_tabs](https://github.com/iced-rs/iced_aw/assets/40620628/abbebc9b-5dde-4cf0-a484-265f53bf2e37) ![2024-02-29_18-00-51_tabs](https://github.com/iced-rs/iced_aw/assets/40620628/72e4e0eb-3f92-4d12-94ee-9f75c6c785c8)

looks like this behavior was introduced in #206

this pull just changes it to always use the strong highlight color, similar to how was before

![2024-02-29_18-01-36_NVIDIA_Share](https://github.com/iced-rs/iced_aw/assets/40620628/6f2df971-ed42-4766-8339-8fe252618bf9)
