### PR TITLE
Add font size to date picker

### DIFF
--- a/src/core/date.rs
+++ b/src/core/date.rs
@@ -204,18 +204,10 @@ const fn num_days_of_month(year: i32, month: u32) -> u32 {
     }
 }
 
-/// Gets the string representation of the year of the given date.
-
+/// Gets the string representation of the date of the given month and date.
 #[must_use]
-pub fn year_as_string(date: NaiveDate) -> String {
-    date.format("%Y").to_string()
-}
-
-/// Gets the string representation of the month of the given date.
-
-#[must_use]
-pub fn month_as_string(date: NaiveDate) -> String {
-    date.format("%B").to_string()
+pub fn date_as_string(date: NaiveDate) -> String {
+    date.format("%Y %B").to_string()
 }
 
 /// Gets the length of the longest month name.
@@ -237,8 +229,11 @@ pub static MAX_MONTH_STR_LEN: Lazy<usize> = Lazy::new(|| {
 
     let max = months
         .iter()
-        .map(|m| month_as_string(*m))
-        .map(|s| s.len())
+        .map(|m| {
+            let d = date_as_string(*m);
+            let (_, s) = d.split_once(' ').expect("Date must contain space");
+            s.len()
+        })
         .max()
         .expect("There should be a maximum element");
 

--- a/src/native/date_picker.rs
+++ b/src/native/date_picker.rs
@@ -9,6 +9,7 @@ use iced::{
     advanced::{
         layout::{Limits, Node},
         renderer,
+        text::Renderer as _,
         widget::{
             self,
             tree::{Tag, Tree},
@@ -21,6 +22,7 @@ use iced::{
     Element,
     Event,
     Length,
+    Pixels,
     Point,
     Rectangle,
     Renderer, // the actual type
@@ -78,6 +80,8 @@ where
     /// The buttons of the overlay.
     overlay_state: Element<'a, Message, Theme, Renderer>,
     //button_style: <Renderer as button::Renderer>::Style, // clone not satisfied
+    /// The font and icon size of the [`DatePickerOverlay`] or `None` for the default
+    font_size: Option<Pixels>,
 }
 
 impl<'a, Message, Theme> DatePicker<'a, Message, Theme>
@@ -120,6 +124,7 @@ where
             style: <Theme as StyleSheet>::Style::default(),
             overlay_state: DatePickerOverlayButtons::default().into(),
             //button_style: <Renderer as button::Renderer>::Style::default(),
+            font_size: None,
         }
     }
 
@@ -128,6 +133,13 @@ where
     pub fn style(mut self, style: <Theme as StyleSheet>::Style) -> Self {
         self.style = style;
         //self.button_style = style.into();
+        self
+    }
+
+    /// Sets the font and icon size of the [`DatePicker`].
+    #[must_use]
+    pub fn font_size<P: Into<Pixels>>(mut self, size: P) -> Self {
+        self.font_size = Some(size.into());
         self
     }
 }
@@ -286,6 +298,7 @@ where
                 position,
                 self.style.clone(),
                 &mut state.children[1],
+                self.font_size.unwrap_or_else(|| renderer.default_size()),
             )
             .overlay(),
         )

--- a/src/native/overlay/date_picker.rs
+++ b/src/native/overlay/date_picker.rs
@@ -384,7 +384,7 @@ where
         let limits = Limits::new(Size::ZERO, bounds)
             .shrink(Padding::from(PADDING))
             .width(Length::Shrink)
-            .height(Length::Fill);
+            .height(Length::Shrink);
 
         // Pre-Buttons TODO: get rid of it
         let cancel_limits = limits;
@@ -417,7 +417,7 @@ where
                     )
                     .push(
                         // Month
-                        Text::new("September").width(Length::Shrink),
+                        Text::new("September").size(font_size).width(Length::Shrink),
                     )
                     .push(
                         // Right Month arrow
@@ -447,7 +447,7 @@ where
                     )
                     .push(
                         // Year
-                        Text::new("9999").width(Length::Shrink),
+                        Text::new("9999").size(font_size).width(Length::Shrink),
                     )
                     .push(
                         // Right Year arrow


### PR DESCRIPTION
Adds the ability to set font size on the date picker overlay as discussed in #208.
Also dynamically changes the size of the overlay to best fit the relevant font size.