### PR TITLE
only activate required iced-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,9 +3991,9 @@ checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "yansi"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yazi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,8 @@ itertools = { version = "0.12.1", optional = true }
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "b474a2b7a763dcde6a377cb409001a7b5285ee8d"
 version = "0.12.1"
-features = ["advanced", "lazy", "tokio",]
+default-features = false
+features = ["advanced"]
 
 [profile.dev.package."*"]
 opt-level = 2
@@ -120,9 +121,9 @@ members = [
 #git = "https://github.com/iced-rs/iced.git"
 #rev = "b474a2b7a763dcde6a377cb409001a7b5285ee8d"
 version = "0.12.1"
-features = ["advanced", "lazy", "tokio", "canvas"]
+default-features = false
+features = ["advanced"]
 
 [workspace.dependencies.iced_aw]
 path = "./"
 default-features = false
-features = ["num-traits"]

--- a/examples/WidgetIDReturn/Cargo.toml
+++ b/examples/WidgetIDReturn/Cargo.toml
@@ -11,5 +11,7 @@ iced_aw = { workspace = true, features = [
     "number_input",
     "icons",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }
 num-traits = "0.2.16"

--- a/examples/badge/Cargo.toml
+++ b/examples/badge/Cargo.toml
@@ -9,5 +9,9 @@ edition = "2021"
 [dependencies]
 iced_aw = { workspace = true, features = [
     "badge",
+    "icons",
 ] }
-iced.workspace = true
+
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/card/Cargo.toml
+++ b/examples/card/Cargo.toml
@@ -10,4 +10,6 @@ edition = "2021"
 iced_aw = { workspace = true, features = [
     "card", "icons"
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/color_picker/Cargo.toml
+++ b/examples/color_picker/Cargo.toml
@@ -10,4 +10,6 @@ edition = "2021"
 iced_aw = { workspace = true, features = [
     "color_picker",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/context_menu/Cargo.toml
+++ b/examples/context_menu/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 iced_aw = { workspace = true, features = [
     "context_menu",
+    "icons",
 ] }
 iced.workspace = true

--- a/examples/cupertino/cupertino_spinner/Cargo.toml
+++ b/examples/cupertino/cupertino_spinner/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced.workspace = true
+iced = { workspace = true, features = ["tokio"] }
 iced_aw = { path = "../../../", features = ["cupertino"] }
 tokio = { version = "1.29.1", features = ["time"] }
-

--- a/examples/drop_down/Cargo.toml
+++ b/examples/drop_down/Cargo.toml
@@ -8,5 +8,8 @@ edition = "2021"
 [dependencies]
 iced_aw = { workspace = true, features = [
     "drop_down",
+    "icons",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/floating_element multioverlay/Cargo.toml
+++ b/examples/floating_element multioverlay/Cargo.toml
@@ -11,4 +11,6 @@ iced_aw = { workspace = true, features = [
     "floating_element",
     "icons",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/floating_element_anchors/Cargo.toml
+++ b/examples/floating_element_anchors/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 [dependencies]
 iced_aw = { workspace = true, features = [
     "floating_element",
+    "icons",
 ] }
 iced.workspace = true

--- a/examples/font_loading/Cargo.toml
+++ b/examples/font_loading/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced.workspace = true 
+iced = { workspace = true, features = [
+    "wgpu",
+] } 
 iced_aw = { workspace = true, features = [ "icons" ] }
 

--- a/examples/grid/Cargo.toml
+++ b/examples/grid/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Alexander van Saase <avsaase [at] gmail.com>"]
 edition = "2021"
 
 [dependencies]
-iced_aw = { workspace = true, features = ["grid"] }
+iced_aw = { workspace = true, features = ["grid", "icons"] }
 iced.workspace = true

--- a/examples/menu/Cargo.toml
+++ b/examples/menu/Cargo.toml
@@ -10,4 +10,4 @@ iced_aw = { workspace = true, features = [
     "quad",
     "icons"
 ] }
-iced = {workspace = true, features = ["svg"]}
+iced = {workspace = true, features = ["svg", "wgpu"]}

--- a/examples/modal/Cargo.toml
+++ b/examples/modal/Cargo.toml
@@ -10,5 +10,6 @@ edition = "2021"
 iced_aw = { workspace = true, features = [
     "card",
     "modal",
+    "icons",
 ] }
 iced.workspace = true

--- a/examples/modal_component/Cargo.toml
+++ b/examples/modal_component/Cargo.toml
@@ -10,5 +10,8 @@ edition = "2021"
 iced_aw = { workspace = true, features = [
     "card",
     "modal",
+    "icons",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "lazy",
+] }

--- a/examples/multiple_modals/Cargo.toml
+++ b/examples/multiple_modals/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced_aw = { workspace = true, features = ["card", "modal"] }
-iced.workspace = true
+iced_aw = { workspace = true, features = ["card", "modal", "icons"] }
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/number_input/Cargo.toml
+++ b/examples/number_input/Cargo.toml
@@ -11,4 +11,7 @@ iced_aw = { workspace = true, features = [
     "number_input",
     "icons",
 ] }
-iced.workspace = true
+
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/selection_list/Cargo.toml
+++ b/examples/selection_list/Cargo.toml
@@ -11,5 +11,6 @@ publish = false
 [dependencies]
 iced_aw = { workspace = true, features = [
     "selection_list",
+    "icons",
 ] }
 iced.workspace = true

--- a/examples/sliderbar/Cargo.toml
+++ b/examples/sliderbar/Cargo.toml
@@ -9,5 +9,9 @@ edition = "2021"
 [dependencies]
 iced_aw = { workspace = true, features = [
     "slide_bar",
+    "icons",
+    "number_input",
 ] }
-iced.workspace = true
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/spinner/Cargo.toml
+++ b/examples/spinner/Cargo.toml
@@ -10,5 +10,6 @@ publish = false
 [dependencies]
 iced_aw = { workspace = true, features = [
     "spinner",
+    "icons",
 ] }
 iced.workspace = true

--- a/examples/split/Cargo.toml
+++ b/examples/split/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced_aw = { workspace = true, features = ["split"] }
+iced_aw = { workspace = true, features = ["split", "icons"] }
 iced.workspace = true

--- a/examples/split_scroller/Cargo.toml
+++ b/examples/split_scroller/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced_aw = { workspace = true, features = ["split"] }
+iced_aw = { workspace = true, features = ["split", "icons"] }
 iced.workspace = true
 once_cell = "1.17.1"

--- a/examples/tab_bar/Cargo.toml
+++ b/examples/tab_bar/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced_aw = { workspace = true, features = ["tab_bar"] }
-iced.workspace = true
+iced_aw = { workspace = true, features = ["tab_bar", "icons"] }
+iced = { workspace = true, features = [
+    "wgpu",
+] }

--- a/examples/tabs/Cargo.toml
+++ b/examples/tabs/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced_aw = { workspace = true, features = ["tabs"] }
+iced_aw = { workspace = true, features = ["tabs", "icons"] }
 iced = { workspace = true, features = [ "image"] }

--- a/examples/wrap/Cargo.toml
+++ b/examples/wrap/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 iced_aw = { workspace = true, features = [
     "wrap",
     "number_input",
+    "icons",
 ] }
 rand = "0.8"
 iced.workspace = true


### PR DESCRIPTION
They are automatically activated for users of this crate.

My specific use-case:
For some reason, starting with iced-0.12 activating the wgpu-feature results in a "unwrap on a None-value" panic when executing on a rasperry pi.
Additionally, I don't want to activate the "tokio"-feature, since I don't use it for anything else (yet), and tokio isn't exactly small.

All examples are still compiling (added missing "icons"-feature where rustc was complaining).
However, I noticed some weirdness (not addressed here, to keep the scope small):
- wgpu requirement in examples:
  - panic on tab_bar (start) and multiple_modals (after button press)
  - sometimes starts with black window
  - color-picker bottom line stays empty
  - menu: when focusing an item, every other item is only a black box
- cuppertino_switch has weird behaviour (e.g. toggling both visually)
- split_scroller
  - panics when used with "wgpu" feature
  - horizontal scrolling is not shown in slidebar at the bottom
- folder for `slidebar` is named `sliderbar` (extra "r" in the middle)
- folder for `widget_id` is named `WidgetIDReturn`