### PR TITLE
fix: button doesn't highlight when it is hovered

### DIFF
--- a/examples/floating_element/src/main.rs
+++ b/examples/floating_element/src/main.rs
@@ -156,4 +156,25 @@ impl button::StyleSheet for CircleButtonStyle {
 
         appearance
     }
+
+    fn hovered(&self, style: &Self::Style) -> Appearance {
+        let mut appearance = style.hovered(&self.theme);
+        appearance.border.radius = 25.0.into();
+
+        appearance
+    }
+
+    fn pressed(&self, style: &Self::Style) -> Appearance {
+        let mut appearance = style.pressed(&self.theme);
+        appearance.border.radius = 25.0.into();
+
+        appearance
+    }
+
+    fn disabled(&self, style: &Self::Style) -> Appearance {
+        let mut appearance = style.disabled(&self.theme);
+        appearance.border.radius = 25.0.into();
+
+        appearance
+    }
 }


### PR DESCRIPTION
this PR can fix the example button doesn't highlight when it is hovered