### PR TITLE
Fix number input over/underflow

### DIFF
--- a/src/widgets/number_input.rs
+++ b/src/widgets/number_input.rs
@@ -227,7 +227,7 @@ where
         if self.bounds.1 - self.bounds.0 < self.step || self.value < self.bounds.0 + self.step {
             self.value = self.bounds.0;
         } else {
-            self.value = self.value - self.step;
+            self.value -= self.step;
         }
         shell.publish((self.on_change)(self.value));
     }
@@ -237,7 +237,7 @@ where
         if self.bounds.1 - self.bounds.0 < self.step || self.value > self.bounds.1 - self.step {
             self.value = self.bounds.1;
         } else {
-            self.value = self.value + self.step;
+            self.value += self.step;
         }
         shell.publish((self.on_change)(self.value));
     }

--- a/src/widgets/number_input.rs
+++ b/src/widgets/number_input.rs
@@ -224,28 +224,22 @@ where
 
     /// Decrease current value by step of the [`NumberInput`].
     fn decrease_val(&mut self, shell: &mut Shell<Message>) {
-        if self.value > self.bounds.0 {
-            let new_val = self.value - self.step;
-            self.value = if new_val > self.bounds.0 {
-                new_val
-            } else {
-                self.bounds.0
-            };
-            shell.publish((self.on_change)(self.value));
+        if self.bounds.1 - self.bounds.0 < self.step || self.value < self.bounds.0 + self.step {
+            self.value = self.bounds.0;
+        } else {
+            self.value = self.value - self.step;
         }
+        shell.publish((self.on_change)(self.value));
     }
 
     /// Increase current value by step of the [`NumberInput`].
     fn increase_val(&mut self, shell: &mut Shell<Message>) {
-        if self.value < self.bounds.1 {
-            let new_val = self.value + self.step;
-            self.value = if new_val < self.bounds.1 {
-                new_val
-            } else {
-                self.bounds.1
-            };
-            shell.publish((self.on_change)(self.value));
+        if self.bounds.1 - self.bounds.0 < self.step || self.value > self.bounds.1 - self.step {
+            self.value = self.bounds.1;
+        } else {
+            self.value = self.value + self.step;
         }
+        shell.publish((self.on_change)(self.value));
     }
 }
 


### PR DESCRIPTION
Fixes #235.

This code change makes sure to not do any operations that might overflow or underflow.

The code makes the assumption that it does not receive the widget in a broken state, ie the invariant

```rust
self.bounds.0 <= self.value <= self.bounds.1
```

must be true for the code to be correct. If it is, then the result after the operation will uphold the same invariant.

Such a topic is very error prone, so please feel free to try and find problems in the code I wrote.