### PR TITLE
Replace Length with impl Into<Length> in width/height APIs

### DIFF
--- a/src/widgets/badge.rs
+++ b/src/widgets/badge.rs
@@ -94,8 +94,8 @@ where
 
     /// Sets the height of the [`Badge`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -115,8 +115,8 @@ where
 
     /// Sets the width of the [`Badge`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 }

--- a/src/widgets/card.rs
+++ b/src/widgets/card.rs
@@ -129,8 +129,8 @@ where
 
     /// Sets the height of the [`Card`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -200,8 +200,8 @@ where
 
     /// Sets the width of the [`Card`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 }

--- a/src/widgets/cupertino/cupertino_spinner.rs
+++ b/src/widgets/cupertino/cupertino_spinner.rs
@@ -76,8 +76,8 @@ impl CupertinoSpinner {
 
     /// Sets the height of the [`CupertinoSpinner`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -92,8 +92,8 @@ impl CupertinoSpinner {
 
     /// Sets the width of the [`CupertinoSpinner`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 }

--- a/src/widgets/number_input.rs
+++ b/src/widgets/number_input.rs
@@ -217,8 +217,8 @@ where
 
     /// Sets the width of the [`NumberInput`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 

--- a/src/widgets/segmented_button.rs
+++ b/src/widgets/segmented_button.rs
@@ -88,15 +88,15 @@ where
 
     /// Sets the width of the [`SegmentedButton`](SegmentedButton).
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`SegmentedButton`](SegmentedButton).
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 

--- a/src/widgets/selection_list.rs
+++ b/src/widgets/selection_list.rs
@@ -125,15 +125,15 @@ where
 
     /// Sets the width of the [`SelectionList`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`SelectionList`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 

--- a/src/widgets/spinner.rs
+++ b/src/widgets/spinner.rs
@@ -51,15 +51,15 @@ impl Spinner {
 
     /// Sets the width of the [`Spinner`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Spinner`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 

--- a/src/widgets/split.rs
+++ b/src/widgets/split.rs
@@ -137,15 +137,15 @@ where
 
     /// Sets the width of the [`Split`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 
     /// Sets the height of the [`Split`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 

--- a/src/widgets/tab_bar.rs
+++ b/src/widgets/tab_bar.rs
@@ -215,8 +215,8 @@ where
 
     /// Sets the height of the [`TabBar`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -332,8 +332,8 @@ where
 
     /// Sets the width of the [`TabBar`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 }

--- a/src/widgets/tabs.rs
+++ b/src/widgets/tabs.rs
@@ -155,8 +155,8 @@ where
 
     /// Sets the height of the [`Tabs`].
     #[must_use]
-    pub fn height(mut self, height: Length) -> Self {
-        self.height = height;
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
         self
     }
 
@@ -282,8 +282,8 @@ where
 
     /// Sets the width of the [`Tabs`].
     #[must_use]
-    pub fn width(mut self, width: Length) -> Self {
-        self.width = width;
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
         self
     }
 }


### PR DESCRIPTION
Widgets in iced allow to change their height and their width with an API like this :

```rust
pub fn width(mut self, width: impl Into<Length>) -> Self
```

This is especially useful when setting a fixed width/height:

```rust
my_widget.width(30);
```

instead of 

```rust
my_widget.width(Length::Fixed(30.));
```

This PR proposes to change the API to make it more in line with the one in iced.