### PR TITLE
Toggle Menu Bar on Click

### DIFF
--- a/src/widgets/menu/menu_bar.rs
+++ b/src/widgets/menu/menu_bar.rs
@@ -223,7 +223,7 @@ where
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 if cursor.is_over(bar_bounds) && bar.is_pressed {
-                    bar.open = true;
+                    bar.open = !bar.open;
                     bar.is_pressed = false;
                     for (i, l) in layout.children().enumerate() {
                         if cursor.is_over(l.bounds()) {


### PR DESCRIPTION
## Requirement

In our [pigg](https://github.com/andrewdavidmackenzie/pigg) app, we encountered a scenario where it was necessary to close the menu bar when the user clicks on the menu bar itself.

![2024-07-13 23-27-19](https://github.com/user-attachments/assets/bd438b07-6cd0-410b-8b3f-66d35f34e0e4)

## Implementation
To address this need, I implemented the feature to close the menu bar when clicked. When the menu bar is clicked, it toggles its open/close state.

### Example:
![2024-07-13 23-43-59](https://github.com/user-attachments/assets/e94775d4-e361-4236-940f-14e31660ea90)

Any feedback is appreciated!
