### PR TITLE
use new alignment methods from iced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.26"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53b0a3d5760cd2ba9b787ae0c6440ad18ee294ff71b05e3381c900a7d16cfd"
+checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -238,7 +238,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -267,13 +267,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -412,9 +412,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "calloop"
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.101"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
+checksum = "47de7e88bbbd467951ae7f5a6f34f70d1b4d9cfce53d5fd70f74ebe118b3db56"
 dependencies = [
  "jobserver",
  "libc",
@@ -496,14 +496,14 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "clipboard-win"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f4473f5144e20d9aceaf2972478f06ddf687831eafeeb434fbaf0acc4144ad"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
 dependencies = [
  "error-code",
 ]
@@ -953,7 +953,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1136,7 +1136,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "bitflags 2.6.0",
  "bytes",
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "futures",
  "iced_core",
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -1595,7 +1595,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1607,7 +1607,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1619,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -1656,11 +1656,12 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
  "num-traits",
+ "once_cell",
  "rustc-hash",
  "thiserror",
  "unicode-segmentation",
@@ -1669,7 +1670,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.13.0-dev"
-source = "git+https://github.com/iced-rs/iced.git#b9eb86199afe0f2d936eb4ab90af5b2a2c32a87a"
+source = "git+https://github.com/iced-rs/iced.git#d9a29f51760efc0b2a9d3b0947c15c51897a7a5e"
 dependencies = [
  "iced_futures",
  "iced_graphics",
@@ -1866,7 +1867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1920,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -2124,13 +2125,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2189,7 +2190,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2488,11 +2489,11 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b41438d2fc63c46c74a2203bf5ccd82c41ba04347b2fcf5754f230b167067d5"
+checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
 dependencies = [
- "ttf-parser 0.21.1",
+ "ttf-parser 0.24.0",
 ]
 
 [[package]]
@@ -2516,7 +2517,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2570,7 +2571,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2615,7 +2616,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2650,7 +2651,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2763,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "6f24d770aeca0eacb81ac29dfbc55ebcc09312fdd1f8bbecdc7e4a84e000e3b4"
 dependencies = [
  "memchr",
 ]
@@ -2926,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.37"
+version = "0.8.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+checksum = "1aee83dc281d5a3200d37b299acd13b81066ea126a7f16f0eae70fc9aed241d9"
 dependencies = [
  "bytemuck",
 ]
@@ -3033,9 +3034,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de61fa7334ee8ee1f5c3c58dcc414fb9361e7e8f5bff9d45f4d69eeb89a7169"
+checksum = "7555fcb4f753d095d734fdefebb0ad8c98478a21db500492d87c55913d3b0086"
 dependencies = [
  "ab_glyph",
  "log",
@@ -3060,22 +3061,22 @@ checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3086,7 +3087,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3331,9 +3332,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3388,22 +3389,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3487,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3536,7 +3537,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -3562,9 +3563,9 @@ checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "ttf-parser"
-version = "0.21.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+checksum = "8686b91785aff82828ed725225925b33b4fde44c4bb15876e5f7c832724c420a"
 
 [[package]]
 name = "typenum"
@@ -3753,7 +3754,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -3787,7 +3788,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3815,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e9e6b6d4a2bb4e7e69433e0b35c7923b95d4dc8503a84d25ec917a4bbfdf07"
+checksum = "269c04f203640d0da2092d1b8d89a2d081714ae3ac2f1b53e99f205740517198"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -3829,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.3"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e63801c85358a431f986cffa74ba9599ff571fc5774ac113ed3b490c19a1133"
+checksum = "08bd0f46c069d3382a36c8666c1b9ccef32b8b04f41667ca1fef06a1adcc2982"
 dependencies = [
  "bitflags 2.6.0",
  "rustix",
@@ -3852,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.3"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a206e8b2b53b1d3fcb9428fec72bc278ce539e2fa81fe2bfc1ab27703d5187b9"
+checksum = "09414bcf0fd8d9577d73e9ac4659ebc45bcc9cff1980a350543ad8e50ee263b2"
 dependencies = [
  "rustix",
  "wayland-client",
@@ -3901,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67da50b9f80159dec0ea4c11c13e24ef9e7574bd6ce24b01860a175010cea565"
+checksum = "edf466fc49a4feb65a511ca403fec3601494d0dee85dbf37fff6fa0dd4eec3b6"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -3912,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
+checksum = "4a6754825230fa5b27bafaa28c30b3c9e72c55530581220cef401fa422c0fae7"
 dependencies = [
  "dlib",
  "log",
@@ -4122,7 +4123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4131,7 +4132,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4149,7 +4150,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4184,18 +4185,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -4212,9 +4213,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4230,9 +4231,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4248,15 +4249,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4272,9 +4273,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4290,9 +4291,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4308,9 +4309,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4326,9 +4327,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
@@ -4501,9 +4502,9 @@ checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
 
 [[package]]
 name = "zbus"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23915fcb26e7a9a9dc05fd93a9870d336d6d032cd7e8cebf1c5c37666489fdd5"
+checksum = "851238c133804e0aa888edf4a0229481c753544ca12a60fd1c3230c8a500fe40"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -4539,14 +4540,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bcca0b586d2f8589da32347b4784ba424c4891ed86aa5b50d5e88f6b2c4f5d"
+checksum = "8d5a3f12c20bd473be3194af6b49d50d7bb804ef3192dc70eddedb26b85d9da7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "zvariant_utils",
 ]
 
@@ -4569,22 +4570,22 @@ checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4598,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa6d31a02fbfb602bfde791de7fedeb9c2c18115b3d00f3a36e489f46ffbbc7"
+checksum = "1724a2b330760dc7d2a8402d841119dc869ef120b139d29862d6980e9c75bfc9"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4611,14 +4612,14 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642bf1b6b6d527988b3e8193d20969d53700a36eac734d21ae6639db168701c8"
+checksum = "55025a7a518ad14518fb243559c058a2e5b848b015e31f1d90414f36e3317859"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "zvariant_utils",
 ]
 
@@ -4630,5 +4631,5 @@ checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]

--- a/src/style/menu_bar.rs
+++ b/src/style/menu_bar.rs
@@ -34,15 +34,15 @@ impl std::default::Default for Style {
         Self {
             bar_background: Color::from([0.85; 3]).into(),
             bar_border: Border {
-                radius: [8.0; 4].into(),
+                radius: 8.0.into(),
                 ..Default::default()
             },
             bar_shadow: Shadow::default(),
-            bar_background_expand: [5; 4].into(),
+            bar_background_expand: 5.into(),
 
             menu_background: Color::from([0.85; 3]).into(),
             menu_border: Border {
-                radius: [8.0; 4].into(),
+                radius: 8.0.into(),
                 ..Default::default()
             },
             menu_shadow: Shadow {
@@ -50,10 +50,10 @@ impl std::default::Default for Style {
                 offset: Vector::ZERO,
                 blur_radius: 10.0,
             },
-            menu_background_expand: [5; 4].into(),
+            menu_background_expand: 5.into(),
             path: Color::from([0.3; 3]).into(),
             path_border: Border {
-                radius: [6.0; 4].into(),
+                radius: 6.0.into(),
                 ..Default::default()
             },
         }

--- a/src/widgets/menu/menu_tree.rs
+++ b/src/widgets/menu/menu_tree.rs
@@ -226,7 +226,7 @@ where
 
         let offset_bounds = Rectangle::new(offset_position, offset_size);
         let children_bounds = Rectangle::new(children_position, children_size);
-        let check_bounds = pad_rectangle(children_bounds, [check_bounds_width; 4].into());
+        let check_bounds = pad_rectangle(children_bounds, check_bounds_width.into());
 
         let menu_state = tree.state.downcast_mut::<MenuState>();
 

--- a/src/widgets/overlay/color_picker.rs
+++ b/src/widgets/overlay/color_picker.rs
@@ -21,7 +21,7 @@ use iced::{
         widget::{self, tree::Tree},
         Clipboard, Layout, Overlay, Renderer as _, Shell, Text, Widget,
     },
-    alignment::{self, Horizontal, Vertical},
+    alignment::{Horizontal, Vertical},
     event,
     keyboard,
     mouse::{self, Cursor},
@@ -109,7 +109,7 @@ where
             state: overlay_state,
             cancel_button: Button::new(
                 iced::widget::Text::new(icon_to_string(Bootstrap::X))
-                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill)
                     .font(crate::BOOTSTRAP_FONT),
             )
@@ -117,7 +117,7 @@ where
             .on_press(on_cancel.clone()),
             submit_button: Button::new(
                 iced::widget::Text::new(icon_to_string(Bootstrap::Check))
-                    .horizontal_alignment(alignment::Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill)
                     .font(crate::BOOTSTRAP_FONT),
             )
@@ -972,14 +972,14 @@ where
     for _ in 0..4 {
         rgba_colors = rgba_colors.push(
             Row::new()
-                .align_items(Alignment::Center)
+                .align_y(Alignment::Center)
                 .spacing(SPACING)
                 .padding(PADDING)
                 .height(Length::Fill)
                 .push(
                     widget::Text::new("X:")
-                        .horizontal_alignment(Horizontal::Center)
-                        .vertical_alignment(Vertical::Center),
+                        .align_x(Horizontal::Center)
+                        .align_y(Vertical::Center),
                 )
                 .push(
                     Row::new()
@@ -988,8 +988,8 @@ where
                 )
                 .push(
                     widget::Text::new("XXX")
-                        .horizontal_alignment(Horizontal::Center)
-                        .vertical_alignment(Vertical::Center),
+                        .align_x(Horizontal::Center)
+                        .align_y(Vertical::Center),
                 ),
         );
     }

--- a/src/widgets/overlay/date_picker.rs
+++ b/src/widgets/overlay/date_picker.rs
@@ -107,7 +107,7 @@ where
                 text::Text::new(icon_to_string(Bootstrap::X))
                     .font(crate::BOOTSTRAP_FONT)
                     .size(font_size)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .width(Length::Fill)
@@ -116,7 +116,7 @@ where
                 text::Text::new(icon_to_string(Bootstrap::Check))
                     .font(crate::BOOTSTRAP_FONT)
                     .size(font_size)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .width(Length::Fill)
@@ -399,7 +399,7 @@ where
                 Row::new()
                     .width(Length::Shrink)
                     .spacing(SPACING)
-                    .align_items(Alignment::Center)
+                    .align_y(Alignment::Center)
                     .push(
                         // Left Month arrow
                         Container::new(
@@ -429,7 +429,7 @@ where
                 Row::new()
                     .width(Length::Shrink)
                     .spacing(SPACING)
-                    .align_items(Alignment::Center)
+                    .align_y(Alignment::Center)
                     .push(
                         // Left Year arrow
                         Container::new(
@@ -483,7 +483,7 @@ where
 
         let col = Column::<Message, Theme, Renderer>::new()
             .spacing(SPACING)
-            .align_items(Alignment::Center)
+            .align_x(Alignment::Center)
             .push(month_year)
             .push(days);
 
@@ -948,14 +948,14 @@ where
             cancel_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::X))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .into(),
             submit_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::Check))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .into(),

--- a/src/widgets/overlay/time_picker.rs
+++ b/src/widgets/overlay/time_picker.rs
@@ -115,7 +115,7 @@ where
             cancel_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::X))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .width(Length::Fill)
@@ -123,7 +123,7 @@ where
             submit_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::Check))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .width(Length::Fill)
@@ -969,7 +969,7 @@ where
     let font_size = 1.2 * renderer.default_size().0;
 
     let mut digital_clock_row = Row::<Message, Theme, Renderer>::new()
-        .align_items(Alignment::Center)
+        .align_y(Alignment::Center)
         .height(Length::Shrink)
         .width(Length::Shrink)
         .spacing(1);
@@ -986,7 +986,7 @@ where
         .push(
             // Hour
             Column::new()
-                .align_items(Alignment::Center)
+                .align_x(Alignment::Center)
                 .height(Length::Shrink)
                 .push(
                     // Up Hour arrow
@@ -1012,7 +1012,7 @@ where
         )
         .push(
             Column::new()
-                .align_items(Alignment::Center)
+                .align_x(Alignment::Center)
                 .height(Length::Shrink)
                 .push(
                     // Up Minute arrow
@@ -1041,7 +1041,7 @@ where
             )
             .push(
                 Column::new()
-                    .align_items(Alignment::Center)
+                    .align_x(Alignment::Center)
                     .height(Length::Shrink)
                     .push(
                         // Up Minute arrow
@@ -1733,14 +1733,14 @@ where
             cancel_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::X))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .into(),
             submit_button: Button::new(
                 text::Text::new(icon_to_string(Bootstrap::Check))
                     .font(BOOTSTRAP_FONT)
-                    .horizontal_alignment(Horizontal::Center)
+                    .align_x(Horizontal::Center)
                     .width(Length::Fill),
             )
             .into(),

--- a/src/widgets/quad.rs
+++ b/src/widgets/quad.rs
@@ -50,7 +50,7 @@ impl Default for Quad {
             quad_border: Border {
                 color: Color::TRANSPARENT,
                 width: 0.0,
-                radius: [0.0, 0.0, 0.0, 0.0].into(),
+                radius: 0.0.into(),
             },
             quad_shadow: Shadow::default(),
 
@@ -58,7 +58,7 @@ impl Default for Quad {
             bg_border: Border {
                 color: Color::TRANSPARENT,
                 width: 0.0,
-                radius: [0.0, 0.0, 0.0, 0.0].into(),
+                radius: 0.0.into(),
             },
             bg_shadow: Shadow::default(),
         }

--- a/src/widgets/slide_bar.rs
+++ b/src/widgets/slide_bar.rs
@@ -34,7 +34,7 @@ where
     /// Background color of the bar
     pub background: Option<Color>,
     /// Border radius of the bar
-    pub border_radius: [f32; 4],
+    pub border_radius: f32,
     /// Border width of the bar
     pub border_width: f32,
     /// Border color of the bar
@@ -85,7 +85,7 @@ where
             height: None,
             color: Color::from([0.5; 3]),
             background: None,
-            border_radius: [5.0; 4],
+            border_radius: 5.0,
             border_width: 1.0,
             border_color: Color::BLACK,
             step: T::from(1),

--- a/src/widgets/tab_bar.rs
+++ b/src/widgets/tab_bar.rs
@@ -376,8 +376,8 @@ where
             Text::<Theme, Renderer>::new(icon.to_string())
                 .size(size)
                 .font(font.unwrap_or_default())
-                .horizontal_alignment(alignment::Horizontal::Center)
-                .vertical_alignment(alignment::Vertical::Center)
+                .align_x(alignment::Horizontal::Center)
+                // .align_y(alignment::Horizontal::Center)
                 .shaping(iced::advanced::text::Shaping::Advanced)
                 .width(Length::Shrink)
         }
@@ -395,8 +395,7 @@ where
             Text::<Theme, Renderer>::new(text)
                 .size(size)
                 .font(font.unwrap_or_default())
-                .horizontal_alignment(alignment::Horizontal::Center)
-                .vertical_alignment(alignment::Vertical::Center)
+                .align_x(alignment::Horizontal::Center)
                 .shaping(text::Shaping::Advanced)
                 .width(Length::Shrink)
         }
@@ -409,16 +408,16 @@ where
                     .push(
                         match tab_label {
                             TabLabel::Icon(icon) => Column::new()
-                                .align_items(Alignment::Center)
+                                .align_x(Alignment::Center)
                                 .push(layout_icon(icon, self.icon_size + 1.0, self.font)),
 
                             TabLabel::Text(text) => Column::new()
                                 .padding(5.0)
-                                .align_items(Alignment::Center)
+                                .align_x(Alignment::Center)
                                 .push(layout_text(text, self.text_size + 1.0, self.text_font)),
 
                             TabLabel::IconText(icon, text) => {
-                                let mut column = Column::new().align_items(Alignment::Center);
+                                let mut column = Column::new().align_x(Alignment::Center);
 
                                 match self.position {
                                     Position::Top => {
@@ -437,7 +436,7 @@ where
                                     Position::Right => {
                                         column = column.push(
                                             Row::new()
-                                                .align_items(Alignment::Center)
+                                                .align_y(Alignment::Center)
                                                 .push(layout_text(
                                                     text,
                                                     self.text_size + 1.0,
@@ -453,7 +452,7 @@ where
                                     Position::Left => {
                                         column = column.push(
                                             Row::new()
-                                                .align_items(Alignment::Center)
+                                                .align_y(Alignment::Center)
                                                 .push(layout_icon(
                                                     icon,
                                                     self.icon_size + 1.0,
@@ -487,7 +486,7 @@ where
                         .width(self.tab_width)
                         .height(self.height),
                     )
-                    .align_items(Alignment::Center)
+                    .align_y(Alignment::Center)
                     .padding(self.padding)
                     .width(self.tab_width);
 
@@ -496,7 +495,7 @@ where
                         Row::new()
                             .width(Length::Fixed(self.close_size * 1.3 + 1.0))
                             .height(Length::Fixed(self.close_size * 1.3 + 1.0))
-                            .align_items(Alignment::Center),
+                            .align_y(Alignment::Center),
                     );
                 }
 
@@ -505,7 +504,7 @@ where
             .width(self.width)
             .height(self.height)
             .spacing(self.spacing)
-            .align_items(Alignment::Center);
+            .align_y(Alignment::Center);
 
         let element: Element<Message, Theme, Renderer> = Element::new(row);
         let tab_tree = if let Some(child_tree) = tree.children.get_mut(0) {


### PR DESCRIPTION
I had a few compile errors, I assume because I pulled a newer version of Iced. So here's a commit that fixes those build errors.