### PR TITLE
Adding  helpers and placeholder for typed_input

### DIFF
--- a/examples/typed_input/src/main.rs
+++ b/examples/typed_input/src/main.rs
@@ -37,7 +37,8 @@ impl TypedInputDemo {
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Typed Input:");
-        let txt_minute = typed_input::TypedInput::new(&self.value, Message::TypedInpChanged);
+        let txt_minute =
+            typed_input::TypedInput::new("Placeholder", &self.value, Message::TypedInpChanged);
 
         Container::new(
             Row::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,10 @@ mod platform {
     pub use {crate::widgets::number_input, number_input::NumberInput};
 
     #[doc(no_inline)]
+    #[cfg(feature = "typed_input")]
+    pub use {crate::widgets::typed_input, typed_input::TypedInput};
+
+    #[doc(no_inline)]
     #[cfg(feature = "selection_list")]
     pub use {crate::widgets::selection_list, selection_list::SelectionList};
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -25,6 +25,10 @@ pub type NumberInput<'a, T, Message, Theme, Renderer> =
 
 #[cfg(feature = "typed_input")]
 pub mod typed_input;
+#[cfg(feature = "typed_input")]
+/// A field that can only be filled with a specific type.
+pub type TypedInput<'a, T, Message, Theme, Renderer> =
+    typed_input::TypedInput<'a, T, Message, Theme, Renderer>;
 
 #[cfg(feature = "card")]
 pub mod card;

--- a/src/widgets/helpers.rs
+++ b/src/widgets/helpers.rs
@@ -329,6 +329,25 @@ where
     crate::NumberInput::new(value, bounds, on_changed)
 }
 
+#[cfg(feature = "typed_input")]
+/// Shortcut helper to create a [`TypedInput`] Widget.
+///
+/// [`TypedInput`]: crate::TypedInput
+#[must_use]
+pub fn typed_input<'a, T, Message, Theme, Renderer, F>(
+    value: &T,
+    on_changed: F,
+) -> crate::TypedInput<'a, T, Message, Theme, Renderer>
+where
+    Message: Clone,
+    Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
+    Theme: iced::widget::text_input::Catalog,
+    F: 'static + Fn(T) -> Message + Copy,
+    T: 'static + std::fmt::Display + std::str::FromStr + Clone,
+{
+    crate::TypedInput::new("", value, on_changed)
+}
+
 #[cfg(feature = "selection_list")]
 /// Shortcut helper to create a [`SelectionList`] Widget.
 ///

--- a/src/widgets/number_input.rs
+++ b/src/widgets/number_input.rs
@@ -125,7 +125,7 @@ where
             max: Self::set_max(bounds.end_bound()),
             padding,
             size: None,
-            content: TypedInput::new(&value, on_changed)
+            content: TypedInput::new("", &value, on_changed)
                 .padding(padding)
                 .width(Length::Fixed(127.0))
                 .class(Theme::default_input()),
@@ -640,7 +640,7 @@ where
             .bounds();
         let dec_bounds = mod_children
             .next()
-            .expect("fail to get decreate mod layout")
+            .expect("fail to get decrease mod layout")
             .bounds();
         let is_mouse_over = bounds.contains(cursor.position().unwrap_or_default());
         let is_decrease_disabled = self.value <= self.min || self.min == self.max;
@@ -682,7 +682,7 @@ where
             .bounds();
         let dec_bounds = mod_children
             .next()
-            .expect("fail to get decreate mod layout")
+            .expect("fail to get decrease mod layout")
             .bounds();
         self.content.draw(
             &state.children[0],

--- a/src/widgets/sidebar/column.rs
+++ b/src/widgets/sidebar/column.rs
@@ -234,7 +234,7 @@ where
             &self.children,
             &mut tree.children,
         );
-        let mut container_x = std::f32::MAX;
+        let mut container_x = f32::MAX;
         let mut container_width = 0.0f32;
         for row in node.children() {
             if row.size().width > container_width {

--- a/src/widgets/sidebar/row.rs
+++ b/src/widgets/sidebar/row.rs
@@ -237,7 +237,7 @@ where
             &self.children,
             &mut tree.children,
         );
-        let mut container_y = std::f32::MAX;
+        let mut container_y = f32::MAX;
         let mut container_height = 0.0f32;
         for column in node.children() {
             if column.size().height > container_height {

--- a/src/widgets/typed_input.rs
+++ b/src/widgets/typed_input.rs
@@ -33,7 +33,6 @@ const DEFAULT_PADDING: f32 = 5.0;
 /// }
 ///
 /// let value = 12;
-/// let max = 1275;
 ///
 /// let input = TypedInput::new(
 ///     value,
@@ -76,7 +75,7 @@ where
     /// It expects:
     /// - the current value
     /// - a function that produces a message when the [`TypedInput`] changes
-    pub fn new<F>(value: &T, on_changed: F) -> Self
+    pub fn new<F>(placeholder: &str, value: &T, on_changed: F) -> Self
     where
         F: 'static + Fn(T) -> Message + Copy,
         T: 'a + Clone,
@@ -85,7 +84,7 @@ where
 
         Self {
             value: value.clone(),
-            text_input: text_input::TextInput::new("", format!("{value}").as_str())
+            text_input: text_input::TextInput::new(placeholder, format!("{value}").as_str())
                 .on_input(InternalMessage::OnChange)
                 .on_submit(InternalMessage::OnSubmit)
                 .padding(padding)


### PR DESCRIPTION
I added the helpers I didn't include in my precedent PR (#267).
At the same time I added a placeholder for TypedInput, given the content can be empty