### PR TITLE
Changing the TypedInput APi to a one similar to the TextInput's

### DIFF
--- a/examples/typed_input/src/main.rs
+++ b/examples/typed_input/src/main.rs
@@ -37,8 +37,8 @@ impl TypedInputDemo {
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Typed Input:");
-        let txt_minute =
-            typed_input::TypedInput::new("Placeholder", &self.value, Message::TypedInpChanged);
+        let txt_minute = typed_input::TypedInput::new("Placeholder", &self.value)
+            .on_input(Message::TypedInpChanged);
 
         Container::new(
             Row::new()

--- a/src/widgets/helpers.rs
+++ b/src/widgets/helpers.rs
@@ -310,10 +310,10 @@ where
 pub fn number_input<'a, T, Message, Theme, Renderer, F>(
     value: T,
     bounds: impl RangeBounds<T>,
-    on_changed: F,
+    on_change: F,
 ) -> crate::NumberInput<'a, T, Message, Theme, Renderer>
 where
-    Message: Clone,
+    Message: Clone + 'a,
     Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: crate::style::number_input::ExtendedCatalog,
     F: 'static + Fn(T) -> Message + Copy,
@@ -326,7 +326,7 @@ where
         + Copy
         + Bounded,
 {
-    crate::NumberInput::new(value, bounds, on_changed)
+    crate::NumberInput::new(value, bounds, on_change)
 }
 
 #[cfg(feature = "typed_input")]
@@ -336,7 +336,7 @@ where
 #[must_use]
 pub fn typed_input<'a, T, Message, Theme, Renderer, F>(
     value: &T,
-    on_changed: F,
+    on_change: F,
 ) -> crate::TypedInput<'a, T, Message, Theme, Renderer>
 where
     Message: Clone,
@@ -345,7 +345,7 @@ where
     F: 'static + Fn(T) -> Message + Copy,
     T: 'static + std::fmt::Display + std::str::FromStr + Clone,
 {
-    crate::TypedInput::new("", value, on_changed)
+    crate::TypedInput::new("", value).on_input(on_change)
 }
 
 #[cfg(feature = "selection_list")]


### PR DESCRIPTION
I modified the method on the TypedInput to match the ones on TextInput
And change the on_submit message to send a result, either Ok(value) or an error with the current text when it's not valid