### PR TITLE
Correcting menu (index error when less than 2 items)

### DIFF
--- a/src/widgets/menu/menu_tree.rs
+++ b/src/widgets/menu/menu_tree.rs
@@ -448,8 +448,8 @@ where
 
         let menu_state = tree.state.downcast_ref::<MenuState>();
         let slice = &menu_state.slice;
-        let max_item_slice = self.items.len() - 1.min(slice.end_index);
-        let max_tree_slice = tree.children.len() - 1.min(slice.end_index);
+        let max_item_slice = (self.items.len() - 1).min(slice.end_index);
+        let max_tree_slice = (tree.children.len() - 1).min(slice.end_index);
 
         self.items[slice.start_index..=max_item_slice]
             .iter()


### PR DESCRIPTION
When a menu had at most one item, it was falling with an index out of bound exception.

An empty menu would return :
```sh
thread 'main' panicked at /home/user/.cargo/git/checkouts/iced_aw-d8617147b960a6c7/18cf814/src/widgets/menu/menu_tree.rs:245:25:
index out of bounds: the len is 0 but the index is 0
```

And a menu with one item :
```sh
thread 'main' panicked at /home/user/.cargo/git/checkouts/iced_aw-d8617147b960a6c7/18cf814/src/widgets/menu/menu_tree.rs:454:19:
range end index 2 out of range for slice of length 1
```

It seems to come from missing parenthesis during the comparison.

This PR is supposed to solve that