### PR TITLE
fix max width being reduced by padding in number_input

### DIFF
--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -340,9 +340,7 @@ where
 
     fn layout(&self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
         let num_size = self.size();
-        let limits = limits
-            .width(num_size.width)
-            .height(Length::Shrink);
+        let limits = limits.width(num_size.width).height(Length::Shrink);
         let content = self
             .content
             .layout(&mut tree.children[0], renderer, &limits);

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -342,8 +342,7 @@ where
         let num_size = self.size();
         let limits = limits
             .width(num_size.width)
-            .height(Length::Shrink)
-            .shrink(self.padding);
+            .height(Length::Shrink);
         let content = self
             .content
             .layout(&mut tree.children[0], renderer, &limits);


### PR DESCRIPTION
this prevents the max width of the number_input widget from being reduced by the padding

in this example we have a row with 3 collumns filled with buttons _(set to fill)_ and the number_input _(with 22 padding)_ in the middle.
left is before, right with this change
![2024-09-03-18-18_number_input](https://github.com/user-attachments/assets/1913048b-6eb2-4cae-b79a-5af78490e37a) ![2024-09-03-18-18_number_input (2)](https://github.com/user-attachments/assets/82939e93-3a64-449b-93b5-b1db19c9e896)

_the call to shrink may have been used here to apply padding to the content, but the padding is already set on the content itself so this is not needed_