### PR TITLE
Fix compilation errors with 2 examples that use icons.

### DIFF
--- a/examples/side_bar/main.rs
+++ b/examples/side_bar/main.rs
@@ -45,9 +45,9 @@ fn main() -> iced::Result {
         TabBarExample::update,
         TabBarExample::view,
     )
-    .font(iced_aw::BOOTSTRAP_FONT_BYTES)
-    .font(ICON_BYTES)
-    .run()
+        .font(iced_fonts::REQUIRED_FONT_BYTES)
+        .font(ICON_BYTES)
+        .run()
 }
 
 #[derive(Default)]

--- a/examples/tabs/main.rs
+++ b/examples/tabs/main.rs
@@ -45,7 +45,7 @@ impl From<Icon> for char {
 
 fn main() -> iced::Result {
     iced::application("Tabs example", TabBarExample::update, TabBarExample::view)
-        .font(iced_aw::BOOTSTRAP_FONT_BYTES)
+        .font(iced_fonts::REQUIRED_FONT_BYTES)
         .font(ICON_BYTES)
         .run()
 }


### PR DESCRIPTION
Compilation looks like it was broken by 7d14e42d117a76a2e20bd88bf29117bd4745d2a3

Icons were moved to `iced_fonts` according to the changelog, but it looks like these two examples were missed.

Note: It appears that neither `sidebar` or `tab_bar` examples are compiled when running `cargo build --examples`.

I also note there's no `Build: Passing/Failed` badge for this repo or automated github actions which would likely have highlighted this compilation error earlier.

