### PR TITLE
Fixing the compilation error caused by std Instant on WASM targets

### DIFF
--- a/examples/side_bar/main.rs
+++ b/examples/side_bar/main.rs
@@ -45,9 +45,9 @@ fn main() -> iced::Result {
         TabBarExample::update,
         TabBarExample::view,
     )
-        .font(iced_fonts::REQUIRED_FONT_BYTES)
-        .font(ICON_BYTES)
-        .run()
+    .font(iced_fonts::REQUIRED_FONT_BYTES)
+    .font(ICON_BYTES)
+    .run()
 }
 
 #[derive(Default)]

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -302,7 +302,7 @@ where
     /// Sets the [`Id`] of the underlying [`TextInput`].
     #[must_use]
     pub fn id(mut self, id: impl Into<text_input::Id>) -> Self {
-        self.content = self.content.id( id.into() );
+        self.content = self.content.id(id.into());
         self
     }
 }

--- a/src/widget/spinner.rs
+++ b/src/widget/spinner.rs
@@ -11,9 +11,10 @@ use iced::{
     },
     event::Status,
     mouse::Cursor,
+    time::Instant,
     window, Border, Color, Element, Event, Length, Rectangle, Shadow, Size, Vector,
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// A spinner widget, a circle spinning around the center of the widget.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
I did the changes to only `spinner.rs`. But `cargo fmt` changed the other files.