### PR TITLE
Fixing the backspace issue in number inputs on Mac

### DIFF
--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -495,7 +495,7 @@ where
                         if text == "\u{1}" || text == "\u{3}" {
                             // CTRL + a and CTRL + c
                             forward_to_text(event, shell, child, clipboard)
-                        } else if text == "\u{8}" {
+                        } else if key == &keyboard::Key::Named(keyboard::key::Named::Backspace) {
                             // Backspace
                             if current_text == T::zero().to_string() {
                                 return event::Status::Ignored;


### PR DESCRIPTION
Mac keyboards are using the ‘delete’ button as the backspace for text inputs. So the unicode character is `\u{7f}`. But in other platforms, it is `\u{8}`. `iced_core::keyboard` module is already handling it. So we can re-use that functionality for backspace.  