### PR TITLE
Correcting several issues with `NumberInput`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -36,7 +36,7 @@ repos:
       - id: clippy
 
   - repo: https://github.com/DevinR528/cargo-sort
-    rev: v1.0.9
+    rev: v1.1.0
     hooks:
       - id: cargo-sort
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2024-09-18
 
-### Added 
+### Added
 - Typed Input @Ultraxime
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ default = [
 
 [dependencies]
 cfg-if = "1.0"
-chrono = { version = "0.4.38", optional = true, features = ["wasmbind"]}
+chrono = { version = "0.4.38", optional = true, features = ["wasmbind"] }
+getrandom = { version = "0.2", features = ["js"] }
+iced_fonts = "0.1.1"
 itertools = { version = "0.13.0", optional = true }
 num-format = { version = "0.4.4", optional = true }
 num-traits = { version = "0.2.19", optional = true }
-iced_fonts = "0.1.1"
-getrandom = { version = "0.2", features = ["js"] }
 web-time = "1.1.0"
 
 [dependencies.iced]

--- a/README.md
+++ b/README.md
@@ -164,4 +164,3 @@ Also included in this feature, are two widgets `sidebar::column::FlushColumn` an
 ### Color palette
 
 This crate adds a predefined color palette based on the [CSS color palette](https://www.w3schools.com/cssref/css_colors.asp).
-

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -15,7 +15,8 @@ pub struct NumberInputDemo {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    NumInpChanged(Result<f32, String>),
+    NumInpChanged(f32),
+    NumInpSubmitted,
 }
 
 fn main() -> iced::Result {
@@ -34,19 +35,22 @@ fn main() -> iced::Result {
 
 impl NumberInputDemo {
     fn update(&mut self, message: self::Message) {
-        if let Message::NumInpChanged(Ok(val)) = message {
-            println!("Value changed to {:?}", val);
-            self.value = val;
-        } else if let Message::NumInpChanged(Err(_)) = message  {
-            println!("Error Value reset to 0.0");
-            self.value = 0.0;
+        match message {
+            Message::NumInpChanged(val) => {
+                println!("Value changed to {:?}", val);
+                self.value = val;
+            }
+            Message::NumInpSubmitted => {
+                println!("Value submitted");
+            }
         }
     }
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Number Input:");
-        let txt_minute = number_input(self.value, -10.0..250.0, Message::NumInpChanged)
+        let txt_minute = number_input(&self.value, -10.0..250.0, Message::NumInpChanged)
             .style(number_input::number_input::primary)
+            .on_submit(Message::NumInpSubmitted)
             .step(0.5);
 
         Container::new(

--- a/examples/typed_input.rs
+++ b/examples/typed_input.rs
@@ -15,7 +15,8 @@ pub struct TypedInputDemo {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    TypedInpChanged(Result<f32, String>),
+    TypedInpChanged(f32),
+    TypedInpSubmit(Result<f32, String>),
 }
 
 fn main() -> iced::Result {
@@ -34,16 +35,23 @@ fn main() -> iced::Result {
 
 impl TypedInputDemo {
     fn update(&mut self, message: self::Message) {
-        if let Message::TypedInpChanged(Ok(val)) = message {
-            println!("Value changed to {:?}", val);
-            self.value = val;
+        match message {
+            Message::TypedInpChanged(value) => {
+                println!("Value changed to {}", value);
+                self.value = value;
+            }
+            Message::TypedInpSubmit(Ok(value)) => println!("Value submitted: {}", value),
+            Message::TypedInpSubmit(Err(text)) => {
+                println!("Value submitted while invalid: {}", text)
+            }
         }
     }
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Typed Input:");
         let txt_minute = typed_input::TypedInput::new("Placeholder", &self.value)
-            .on_input(Message::TypedInpChanged);
+            .on_input(Message::TypedInpChanged)
+            .on_submit(Message::TypedInpSubmit);
 
         Container::new(
             Row::new()

--- a/examples/widget_id_return/main.rs
+++ b/examples/widget_id_return/main.rs
@@ -41,7 +41,7 @@ use numberinput::*;
 impl NumberInputDemo {
     fn update(&mut self, message: self::Message) {
         let Message::GenericF32Input((id, val)) = message;
-        self.value[id].value = val.get_data().unwrap_or_default();
+        self.value[id].value = val.get_data();
     }
 
     fn view(&self) -> Element<Message> {

--- a/examples/widget_id_return/numberinput.rs
+++ b/examples/widget_id_return/numberinput.rs
@@ -1,4 +1,4 @@
-use iced::{Element, Length};
+use iced::Element;
 use iced_aw::style::number_input::Style;
 use iced_aw::NumberInput;
 use num_traits::{bounds::Bounded, Num, NumAssignOps};
@@ -14,17 +14,16 @@ pub struct NumInput<V, M> {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NumInputMessage<V> {
-    Change(Result<V, String>),
+    Change(V),
 }
 
 impl<V> NumInputMessage<V>
 where
     V: Num + NumAssignOps + PartialOrd + Display + FromStr + Copy + Bounded,
 {
-    pub fn get_data(&self) -> Result<V, String> {
+    pub fn get_data(&self) -> V {
         match self {
-            NumInputMessage::Change(Ok(data)) => Ok(*data),
-            NumInputMessage::Change(Err(data)) => Err(data.clone()),
+            NumInputMessage::Change(data) => *data,
         }
     }
 }
@@ -33,10 +32,9 @@ impl<V> NumInputMessage<V>
 where
     V: Eq + Copy,
 {
-    pub fn get_enum(&self) -> Result<V, String> {
+    pub fn get_enum(&self) -> V {
         match self {
-            NumInputMessage::Change(Ok(data)) => Ok(*data),
-            NumInputMessage::Change(Err(data)) => Err(data.clone()),
+            NumInputMessage::Change(data) => *data,
         }
     }
 }
@@ -70,9 +68,7 @@ where
         V: 'static,
         M: 'static + Clone,
     {
-        let mut input = NumberInput::new(self.value, min..max, NumInputMessage::Change)
-            .step(step)
-            .width(Length::Shrink);
+        let mut input = NumberInput::new(&self.value, min..max, NumInputMessage::Change).step(step);
 
         if let Some(style) = style {
             input = input.style(move |_theme, _status| style);

--- a/examples/wrap.rs
+++ b/examples/wrap.rs
@@ -89,9 +89,9 @@ struct StrButton {
 #[derive(Debug, Clone)]
 enum Message {
     ChangeAlign(WrapAlign),
-    ChangeSpacing(Result<f32, String>),
-    ChangeLineSpacing(Result<f32, String>),
-    ChangeMinimalLength(Result<f32, String>),
+    ChangeSpacing(f32),
+    ChangeLineSpacing(f32),
+    ChangeMinimalLength(f32),
 }
 
 impl RandStrings {
@@ -100,16 +100,15 @@ impl RandStrings {
             Message::ChangeAlign(align) => {
                 self.align = align.into();
             }
-            Message::ChangeSpacing(Ok(num)) => {
+            Message::ChangeSpacing(num) => {
                 self.spacing = num;
             }
-            Message::ChangeLineSpacing(Ok(num)) => {
+            Message::ChangeLineSpacing(num) => {
                 self.line_spacing = num;
             }
-            Message::ChangeMinimalLength(Ok(num)) => {
+            Message::ChangeMinimalLength(num) => {
                 self.line_minimal_length = num;
             }
-            _ => {}
         }
     }
 
@@ -148,7 +147,7 @@ impl RandStrings {
         let spacing_input = Column::new()
             .push(Text::new("spacing"))
             .push(NumberInput::new(
-                self.spacing,
+                &self.spacing,
                 0.0..500.0,
                 Message::ChangeSpacing,
             ));
@@ -156,7 +155,7 @@ impl RandStrings {
             Column::new()
                 .push(Text::new("line spacing"))
                 .push(NumberInput::new(
-                    self.line_spacing,
+                    &self.line_spacing,
                     0.0..500.0,
                     Message::ChangeLineSpacing,
                 ));
@@ -164,7 +163,7 @@ impl RandStrings {
             Column::new()
                 .push(Text::new("line minimal length"))
                 .push(NumberInput::new(
-                    self.line_minimal_length,
+                    &self.line_minimal_length,
                     0.0..999.9,
                     Message::ChangeMinimalLength,
                 ));

--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -308,7 +308,7 @@ where
 /// [`NumberInput`]: crate::NumberInput
 #[must_use]
 pub fn number_input<'a, T, Message, Theme, Renderer, F>(
-    value: T,
+    value: &T,
     bounds: impl RangeBounds<T>,
     on_change: F,
 ) -> crate::NumberInput<'a, T, Message, Theme, Renderer>
@@ -316,7 +316,7 @@ where
     Message: Clone + 'a,
     Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: crate::style::number_input::ExtendedCatalog,
-    F: 'static + Fn(Result<T, String>) -> Message + Copy,
+    F: 'static + Fn(T) -> Message + Copy,
     T: 'static
         + num_traits::Num
         + num_traits::NumAssignOps
@@ -342,7 +342,7 @@ where
     Message: Clone,
     Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: iced::widget::text_input::Catalog,
-    F: 'static + Fn(Result<T, String>) -> Message + Copy,
+    F: 'static + Fn(T) -> Message + Copy,
     T: 'static + std::fmt::Display + std::str::FromStr + Clone,
 {
     crate::TypedInput::new("", value).on_input(on_change)

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -159,7 +159,7 @@ where
     /// ```
     /// use iced_aw::widget::number_input;
     /// // Creates a range from -5 till 5.
-    /// let input: iced_aw::NumberInput<'_, _, _, iced::Theme, iced::Renderer> = number_input(4 /* my_value */, 0..=4, |_| () /* my_message */).bounds(-5..=5);
+    /// let input: iced_aw::NumberInput<'_, _, _, iced::Theme, iced::Renderer> = number_input(&4 /* my_value */, 0..=4, |_| () /* my_message */).bounds(-5..=5);
     /// ```
     #[must_use]
     pub fn bounds(mut self, bounds: impl RangeBounds<T>) -> Self {

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -75,32 +75,45 @@ where
     /// The step for each modify of the [`NumberInput`].
     step: T,
     /// The min value of the [`NumberInput`].
-    min: T,
+    min: Bound<T>,
     /// The max value of the [`NumberInput`].
-    max: T,
+    max: Bound<T>,
     /// The content padding of the [`NumberInput`].
     padding: iced::Padding,
     /// The text size of the [`NumberInput`].
     size: Option<iced::Pixels>,
     /// The underlying element of the [`NumberInput`].
-    content: TypedInput<'a, T, Message, Theme, Renderer>,
+    content: TypedInput<'a, T, InternalMessage<T>, Theme, Renderer>,
     /// The ``on_change`` event of the [`NumberInput`].
-    on_change: Box<dyn Fn(Result<T, String>) -> Message>,
+    on_change: Box<dyn Fn(T) -> Message>,
+    /// The ``on_submit`` event of the [`NumberInput`].
+    #[allow(clippy::type_complexity)]
+    on_submit: Option<Message>,
+    /// The ``on_paste`` event of the [`NumberInput`]
+    on_paste: Option<Box<dyn 'a + Fn(T) -> Message>>,
     /// The style of the [`NumberInput`].
     class: <Theme as style::number_input::Catalog>::Class<'a>,
     /// The font text of the [`NumberInput`].
     font: Renderer::Font,
-    /// The Width to use for the ``NumberBox`` Default is ``Length::Fill``
-    width: Length,
+    // /// The Width to use for the ``NumberBox`` Default is ``Length::Fill``
+    // width: Length,
     /// Ignore mouse scroll events for the [`NumberInput`] Default is ``false``.
     ignore_scroll_events: bool,
     /// Ignore drawing increase and decrease buttons [`NumberInput`] Default is ``false``.
     ignore_buttons: bool,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::enum_variant_names)]
+enum InternalMessage<T> {
+    OnChange(T),
+    OnSubmit(Result<T, String>),
+    OnPaste(T),
+}
+
 impl<'a, T, Message, Theme, Renderer> NumberInput<'a, T, Message, Theme, Renderer>
 where
-    T: Num + NumAssignOps + PartialOrd + Display + FromStr + Copy + Bounded,
+    T: Num + NumAssignOps + PartialOrd + Display + FromStr + Clone + Bounded + 'a,
     Message: Clone + 'a,
     Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: number_input::ExtendedCatalog,
@@ -108,33 +121,34 @@ where
     /// Creates a new [`NumberInput`].
     ///
     /// It expects:
-    /// - some [`State`]
     /// - the current value
-    /// - the max value
+    /// - the bound values
     /// - a function that produces a message when the [`NumberInput`] changes
-    pub fn new<F>(value: T, bounds: impl RangeBounds<T>, on_change: F) -> Self
+    pub fn new<F>(value: &T, bounds: impl RangeBounds<T>, on_change: F) -> Self
     where
-        F: 'static + Fn(Result<T, String>) -> Message + Copy,
+        F: 'static + Fn(T) -> Message + Clone,
         T: 'static,
     {
         let padding = DEFAULT_PADDING;
 
         Self {
-            value,
+            value: value.clone(),
             step: T::one(),
-            min: Self::set_min(bounds.start_bound()),
-            max: Self::set_max(bounds.end_bound()),
+            min: bounds.start_bound().cloned(),
+            max: bounds.end_bound().cloned(),
             padding,
             size: None,
-            content: TypedInput::new("", &value)
-                .on_input(on_change)
+            content: TypedInput::new("", value)
+                .on_input(InternalMessage::OnChange)
                 .padding(padding)
                 .width(Length::Fixed(127.0))
                 .class(Theme::default_input()),
             on_change: Box::new(on_change),
+            on_submit: None,
+            on_paste: None,
             class: <Theme as style::number_input::Catalog>::default(),
             font: Renderer::Font::default(),
-            width: Length::Shrink,
+            // width: Length::Shrink,
             ignore_scroll_events: false,
             ignore_buttons: false,
         }
@@ -149,17 +163,24 @@ where
     /// ```
     #[must_use]
     pub fn bounds(mut self, bounds: impl RangeBounds<T>) -> Self {
-        self.min = Self::set_min(bounds.start_bound());
-        self.max = Self::set_max(bounds.end_bound());
+        self.min = bounds.start_bound().cloned();
+        self.max = bounds.end_bound().cloned();
 
         self
     }
 
-    /// Sets the content width of the [`NumberInput`].
+    /// Sets the width of the [`NumberInput`].
     #[must_use]
-    pub fn content_width(mut self, width: impl Into<Length>) -> Self {
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.content = self.content.width(width);
         self
+    }
+
+    /// Sets the width of the [`NumberInput`].
+    #[deprecated(since = "0.11.1", note = "use `width` instead")]
+    #[must_use]
+    pub fn content_width(self, width: impl Into<Length>) -> Self {
+        self.width(width)
     }
 
     /// Sets the [`Font`] of the [`Text`].
@@ -194,7 +215,19 @@ where
     /// focused and the enter key is pressed.
     #[must_use]
     pub fn on_submit(mut self, message: Message) -> Self {
-        self.content = self.content.on_submit(move |_| message.clone());
+        self.content = self.content.on_submit(InternalMessage::OnSubmit);
+        self.on_submit = Some(message);
+        self
+    }
+
+    /// Sets the message that should be produced when some text is pasted into the [`NumberInput`], resulting in a valid value
+    #[must_use]
+    pub fn on_paste<F>(mut self, callback: F) -> Self
+    where
+        F: 'a + Fn(T) -> Message,
+    {
+        self.content = self.content.on_paste(InternalMessage::OnPaste);
+        self.on_paste = Some(Box::new(callback));
         self
     }
 
@@ -233,46 +266,74 @@ where
         self
     }
 
-    /// Sets the width of the [`NumberInput`].
-    #[must_use]
-    pub fn width(mut self, width: impl Into<Length>) -> Self {
-        self.width = width.into();
-        self
-    }
-
     /// Decrease current value by step of the [`NumberInput`].
     fn decrease_value(&mut self, shell: &mut Shell<Message>) {
-        if self.value < self.min + self.step {
-            self.value = self.min;
+        if self.valid(&(self.value.clone() - self.step.clone())) {
+            self.value -= self.step.clone();
+        } else if self.value > self.min() {
+            self.value = self.min();
         } else {
-            self.value -= self.step;
+            return;
         }
 
-        shell.publish((self.on_change)(Ok(self.value)));
+        shell.publish((self.on_change)(self.value.clone()));
     }
 
     /// Increase current value by step of the [`NumberInput`].
     fn increase_value(&mut self, shell: &mut Shell<Message>) {
-        if self.value > self.max - self.step {
-            self.value = self.max;
+        if self.valid(&(self.value.clone() + self.step.clone())) {
+            self.value += self.step.clone();
+        } else if self.value < self.max() {
+            self.value = self.max();
         } else {
-            self.value += self.step;
+            return;
         }
-        shell.publish((self.on_change)(Ok(self.value)));
+
+        shell.publish((self.on_change)(self.value.clone()));
     }
 
-    fn set_min(min: Bound<&T>) -> T {
-        match min {
-            Bound::Included(n) | Bound::Excluded(n) => *n,
+    fn min(&self) -> T {
+        match &self.min {
+            Bound::Included(n) => n.clone(),
+            Bound::Excluded(n) => n.clone() + self.step.clone(),
             Bound::Unbounded => T::min_value(),
         }
     }
 
-    fn set_max(max: Bound<&T>) -> T {
-        match max {
-            Bound::Included(n) => *n,
-            Bound::Excluded(n) => *n - T::one(),
+    fn max(&self) -> T {
+        match &self.max {
+            Bound::Included(n) => n.clone(),
+            Bound::Excluded(n) => n.clone() - self.step.clone(),
             Bound::Unbounded => T::max_value(),
+        }
+    }
+
+    fn valid(&self, value: &T) -> bool {
+        (match &self.min {
+            Bound::Included(n) if *n > *value => false,
+            Bound::Excluded(n) if *n >= *value => false,
+            _ => true,
+        }) && (match &self.max {
+            Bound::Included(n) if *n < *value => false,
+            Bound::Excluded(n) if *n <= *value => false,
+            _ => true,
+        })
+    }
+
+    fn can_increase(&self) -> bool {
+        self.valid(&(self.value.clone() + self.step.clone())) || self.value < self.max()
+    }
+
+    fn can_decrease(&self) -> bool {
+        self.valid(&(self.value.clone() - self.step.clone())) || self.value > self.min()
+    }
+
+    fn disabled(&self) -> bool {
+        match (&self.min, &self.max) {
+            (Bound::Included(n) | Bound::Excluded(n), Bound::Included(m) | Bound::Excluded(m)) => {
+                *n >= *m
+            }
+            _ => false,
         }
     }
 
@@ -310,7 +371,7 @@ where
 impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for NumberInput<'a, T, Message, Theme, Renderer>
 where
-    T: Num + NumAssignOps + PartialOrd + Display + FromStr + ToString + Copy + Bounded,
+    T: Num + NumAssignOps + PartialOrd + Display + FromStr + ToString + Clone + Bounded + 'a,
     Message: 'a + Clone,
     Renderer: 'a + iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: number_input::ExtendedCatalog,
@@ -343,7 +404,8 @@ where
     }
 
     fn size(&self) -> Size<Length> {
-        Size::new(self.width, Length::Shrink)
+        // Size::new(self.width, Length::Shrink)
+        Widget::size(&self.content)
     }
 
     fn layout(&self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
@@ -454,9 +516,11 @@ where
             .expect("fail to get decrease mod layout")
             .bounds();
 
-        if self.min == self.max {
+        if self.disabled() {
             return event::Status::Ignored;
         }
+        let can_decrease = self.can_decrease();
+        let can_increase = self.can_increase();
 
         let cursor_position = cursor.position().unwrap_or_default();
         let mouse_over_widget = layout.bounds().contains(cursor_position);
@@ -464,128 +528,177 @@ where
         let mouse_over_dec = dec_bounds.contains(cursor_position);
         let mouse_over_button = mouse_over_inc || mouse_over_dec;
 
+        let modifiers = state.state.downcast_mut::<ModifierState>();
+        let mut value = self.content.text().to_owned();
+
         let child = state.children.get_mut(0).expect("fail to get child");
         let text_input = child
             .state
             .downcast_mut::<text_input::State<Renderer::Paragraph>>();
-        let modifiers = state.state.downcast_mut::<ModifierState>();
 
-        let current_text = self.content.text().to_owned();
+        let mut messages = Vec::new();
+        let mut sub_shell = Shell::new(&mut messages);
 
-        let mut forward_to_text = |event, shell, child, clipboard| {
-            self.content.on_event(
-                child, event, content, cursor, renderer, clipboard, shell, viewport,
+        let mut forward_to_text = |widget: &mut Self, child, clipboard| {
+            widget.content.on_event(
+                child,
+                event.clone(),
+                content,
+                cursor,
+                renderer,
+                clipboard,
+                &mut sub_shell,
+                viewport,
             )
         };
 
-        match &event {
-            Event::Keyboard(ke) => {
+        let mut check_value = |value: &str| {
+            if let Ok(value) = T::from_str(value) {
+                self.valid(&value)
+            } else if value.is_empty() {
+                self.value = T::zero();
+                true
+            } else {
+                false
+            }
+        };
+
+        let status = match &event {
+            Event::Keyboard(key) => {
                 if !text_input.is_focused() {
                     return event::Status::Ignored;
                 }
-                let (key, text) = match ke {
-                    keyboard::Event::KeyPressed { key, text, .. } => (key, text),
-                    keyboard::Event::ModifiersChanged(_) => {
-                        return forward_to_text(event, shell, child, clipboard)
-                    }
+
+                match key {
+                    keyboard::Event::ModifiersChanged(_) => forward_to_text(self, child, clipboard),
                     keyboard::Event::KeyReleased { .. } => return event::Status::Ignored,
-                };
-                match text {
-                    Some(text) => {
-                        if text == "\u{1}" || text == "\u{3}" {
-                            // CTRL + a and CTRL + c
-                            forward_to_text(event, shell, child, clipboard)
-                        } else if key == &keyboard::Key::Named(keyboard::key::Named::Backspace) {
-                            // Backspace
+                    keyboard::Event::KeyPressed {
+                        key,
+                        text,
+                        modifiers,
+                        ..
+                    } => {
+                        let cursor = text_input.cursor();
 
-                            let mut new_val = current_text;
-                            match text_input.cursor().state(&Value::new(&new_val)) {
-                                cursor::State::Index(idx) if idx >= 1 && idx <= new_val.len() => {
-                                    _ = new_val.remove(idx - 1);
-                                }
-                                cursor::State::Selection { start, end }
-                                    if start <= new_val.len() && end <= new_val.len() =>
-                                {
-                                    new_val.replace_range(start.min(end)..start.max(end), "");
-                                }
-                                _ => return event::Status::Ignored,
+                        match key.as_ref() {
+                            keyboard::Key::Character("c" | "a") if modifiers.command() => {
+                                forward_to_text(self, child, clipboard)
                             }
-
-                            if new_val.is_empty() {
-                                new_val = T::zero().to_string();
+                            keyboard::Key::Character("x") if modifiers.command() => {
+                                if let Some((start, end)) = cursor.selection(&Value::new(&value)) {
+                                    let _ = value.drain(start..end);
+                                    if check_value(&value) {
+                                        forward_to_text(self, child, clipboard)
+                                    } else {
+                                        return event::Status::Ignored;
+                                    }
+                                } else {
+                                    return event::Status::Ignored;
+                                }
                             }
+                            keyboard::Key::Character("v") if modifiers.command() => {
+                                let Some(paste) =
+                                    clipboard.read(iced::advanced::clipboard::Kind::Standard)
+                                else {
+                                    return event::Status::Ignored;
+                                };
+                                match cursor.state(&Value::new(&value)) {
+                                    cursor::State::Index(idx) => {
+                                        let () = value.insert_str(idx, &paste);
+                                    }
+                                    cursor::State::Selection { start, end } if end >= start => {
+                                        let () = value.replace_range(start..end, &paste);
+                                    }
+                                    cursor::State::Selection { start, end } => {
+                                        let () = value.replace_range(end..start, &paste);
+                                    }
+                                }
 
-                            match T::from_str(&new_val) {
-                                Ok(val)
-                                    if val >= self.min && val <= self.max && val != self.value =>
-                                {
-                                    self.value = val;
-                                    forward_to_text(event, shell, child, clipboard)
+                                if check_value(&value) {
+                                    forward_to_text(self, child, clipboard)
+                                } else {
+                                    return event::Status::Ignored;
                                 }
-                                Ok(val) if val >= self.min && val <= self.max => {
-                                    forward_to_text(event, shell, child, clipboard)
-                                }
-                                Ok(_) => event::Status::Captured,
-                                _ => forward_to_text(event, shell, child, clipboard),
                             }
-                        } else {
-                            let input = if text == "\u{16}" {
-                                // CTRL + v
-                                match clipboard.read(iced::advanced::clipboard::Kind::Standard) {
-                                    Some(paste) => paste,
-                                    None => return event::Status::Ignored,
-                                }
-                            } else {
-                                text.to_string()
-                            };
-
-                            let input = input.trim();
-
-                            let mut new_val = current_text;
-                            match text_input.cursor().state(&Value::new(&new_val)) {
-                                cursor::State::Index(idx) if idx <= new_val.len() => {
-                                    new_val.insert_str(idx, input);
-                                }
-                                cursor::State::Selection { start, end }
-                                    if start <= new_val.len() && end <= new_val.len() =>
-                                {
-                                    new_val.replace_range(start.min(end)..end.max(start), input);
-                                }
-                                _ => return event::Status::Ignored,
+                            keyboard::Key::Named(keyboard::key::Named::Enter) => {
+                                forward_to_text(self, child, clipboard)
                             }
+                            keyboard::Key::Named(keyboard::key::Named::Backspace) => {
+                                match cursor.state(&Value::new(&value)) {
+                                    cursor::State::Selection { start, end } => {
+                                        let _ = value.drain(start..end);
+                                    }
+                                    cursor::State::Index(idx) if idx > 0 => {
+                                        let _ = value.remove(idx - 1);
+                                    }
+                                    cursor::State::Index(_) => return event::Status::Ignored,
+                                }
 
-                            match T::from_str(&new_val) {
-                                Ok(val)
-                                    if val >= self.min && val <= self.max && val != self.value =>
-                                {
-                                    self.value = val;
-                                    forward_to_text(event, shell, child, clipboard)
+                                if check_value(&value) {
+                                    forward_to_text(self, child, clipboard)
+                                } else {
+                                    return event::Status::Ignored;
                                 }
-                                Ok(val) if val >= self.min && val <= self.max => {
-                                    forward_to_text(event, shell, child, clipboard)
-                                }
-                                Ok(_) => event::Status::Captured,
-                                _ => forward_to_text(event, shell, child, clipboard),
                             }
+                            keyboard::Key::Named(keyboard::key::Named::Delete) => {
+                                match cursor.state(&Value::new(&value)) {
+                                    cursor::State::Selection { start, end } => {
+                                        let _ = value.drain(start..end);
+                                    }
+                                    cursor::State::Index(idx) if idx < value.len() => {
+                                        let _ = value.remove(idx);
+                                    }
+                                    cursor::State::Index(_) => return event::Status::Ignored,
+                                }
+
+                                if check_value(&value) {
+                                    forward_to_text(self, child, clipboard)
+                                } else {
+                                    return event::Status::Ignored;
+                                }
+                            }
+                            keyboard::Key::Named(keyboard::key::Named::ArrowDown)
+                                if can_decrease =>
+                            {
+                                self.decrease_value(shell);
+
+                                event::Status::Captured
+                            }
+                            keyboard::Key::Named(keyboard::key::Named::ArrowUp) if can_increase => {
+                                self.increase_value(shell);
+
+                                event::Status::Captured
+                            }
+                            keyboard::Key::Named(
+                                keyboard::key::Named::ArrowLeft
+                                | keyboard::key::Named::ArrowRight
+                                | keyboard::key::Named::Home
+                                | keyboard::key::Named::End,
+                            ) => forward_to_text(self, child, clipboard),
+                            _ => match text {
+                                Some(text) => {
+                                    match cursor.state(&Value::new(&value)) {
+                                        cursor::State::Index(idx) => {
+                                            let () = value.insert_str(idx, text);
+                                        }
+                                        cursor::State::Selection { start, end } if end >= start => {
+                                            let () = value.replace_range(start..end, text);
+                                        }
+                                        cursor::State::Selection { start, end } => {
+                                            let () = value.replace_range(end..start, text);
+                                        }
+                                    }
+
+                                    if check_value(&value) {
+                                        forward_to_text(self, child, clipboard)
+                                    } else {
+                                        return event::Status::Ignored;
+                                    }
+                                }
+                                None => return event::Status::Ignored,
+                            },
                         }
                     }
-                    None => match key {
-                        keyboard::Key::Named(keyboard::key::Named::ArrowDown) => {
-                            self.decrease_value(shell);
-                            event::Status::Captured
-                        }
-                        keyboard::Key::Named(keyboard::key::Named::ArrowUp) => {
-                            self.increase_value(shell);
-                            event::Status::Captured
-                        }
-                        keyboard::Key::Named(
-                            keyboard::key::Named::ArrowLeft
-                            | keyboard::key::Named::ArrowRight
-                            | keyboard::key::Named::Home
-                            | keyboard::key::Named::End,
-                        ) => forward_to_text(event, shell, child, clipboard),
-                        _ => event::Status::Ignored,
-                    },
                 }
             }
             Event::Mouse(mouse::Event::WheelScrolled { delta })
@@ -624,8 +737,51 @@ where
                 }
                 event::Status::Captured
             }
-            _ => forward_to_text(event, shell, child, clipboard),
+            _ => forward_to_text(self, child, clipboard),
+        };
+        if let Some(redraw) = sub_shell.redraw_request() {
+            shell.request_redraw(redraw);
         }
+        if sub_shell.is_layout_invalid() {
+            shell.invalidate_layout();
+        }
+        if sub_shell.are_widgets_invalid() {
+            shell.invalidate_widgets();
+        }
+
+        for message in messages {
+            match message {
+                InternalMessage::OnChange(value) => {
+                    if self.value != value {
+                        self.value = value.clone();
+                        shell.publish((self.on_change)(value));
+                    };
+                    shell.invalidate_layout();
+                }
+                InternalMessage::OnSubmit(result) => {
+                    if let Err(text) = result {
+                        assert!(
+                            text.is_empty(),
+                            "We shouldn't be able to submit a number input with an invalid value"
+                        );
+                    }
+                    if let Some(on_submit) = &self.on_submit {
+                        shell.publish(on_submit.clone());
+                    };
+                    shell.invalidate_layout();
+                }
+                InternalMessage::OnPaste(value) => {
+                    if self.value != value {
+                        self.value = value.clone();
+                        if let Some(on_paste) = &self.on_paste {
+                            shell.publish(on_paste(value));
+                        }
+                    };
+                    shell.invalidate_layout();
+                }
+            }
+        }
+        status
     }
 
     fn mouse_interaction(
@@ -652,8 +808,8 @@ where
             .expect("fail to get decrease mod layout")
             .bounds();
         let is_mouse_over = bounds.contains(cursor.position().unwrap_or_default());
-        let is_decrease_disabled = self.value <= self.min || self.min == self.max;
-        let is_increase_disabled = self.value >= self.max || self.min == self.max;
+        let is_decrease_disabled = !self.can_decrease();
+        let is_increase_disabled = !self.can_increase();
         let mouse_over_decrease = dec_bounds.contains(cursor.position().unwrap_or_default());
         let mouse_over_increase = inc_bounds.contains(cursor.position().unwrap_or_default());
 
@@ -702,8 +858,8 @@ where
             cursor,
             viewport,
         );
-        let is_decrease_disabled = self.value <= self.min || self.min == self.max;
-        let is_increase_disabled = self.value >= self.max || self.min == self.max;
+        let is_decrease_disabled = !self.can_decrease();
+        let is_increase_disabled = !self.can_increase();
 
         let decrease_btn_style = if is_decrease_disabled {
             style::number_input::Catalog::style(theme, &self.class, Status::Disabled)
@@ -812,7 +968,7 @@ pub struct ModifierState {
 impl<'a, T, Message, Theme, Renderer> From<NumberInput<'a, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: 'a + Num + NumAssignOps + PartialOrd + Display + FromStr + Copy + Bounded,
+    T: 'a + Num + NumAssignOps + PartialOrd + Display + FromStr + Clone + Bounded,
     Message: 'a + Clone,
     Renderer: 'a + iced::advanced::text::Renderer<Font = iced::Font>,
     Theme: 'a + number_input::ExtendedCatalog,

--- a/src/widget/typed_input.rs
+++ b/src/widget/typed_input.rs
@@ -50,12 +50,12 @@ where
     text_input: text_input::TextInput<'a, InternalMessage, Theme, Renderer>,
     text: String,
     /// The ``on_change`` event of the [`TypedInput`].
-    on_change: Option<Box<dyn 'a + Fn(Result<T, String>) -> Message>>,
+    on_change: Option<Box<dyn 'a + Fn(T) -> Message>>,
     /// The ``on_submit`` event of the [`TypedInput`].
     #[allow(clippy::type_complexity)]
     on_submit: Option<Box<dyn 'a + Fn(Result<T, String>) -> Message>>,
     /// The ``on_paste`` event of the [`TypedInput`]
-    on_paste: Option<Box<dyn 'a + Fn(Result<T, String>) -> Message>>,
+    on_paste: Option<Box<dyn 'a + Fn(T) -> Message>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -118,7 +118,7 @@ where
     #[must_use]
     pub fn on_input<F>(mut self, callback: F) -> Self
     where
-        F: 'a + Fn(Result<T, String>) -> Message,
+        F: 'a + Fn(T) -> Message,
     {
         self.text_input = self.text_input.on_input(InternalMessage::OnChange);
         self.on_change = Some(Box::new(callback));
@@ -146,7 +146,7 @@ where
     #[must_use]
     pub fn on_paste<F>(mut self, callback: F) -> Self
     where
-        F: 'a + Fn(Result<T, String>) -> Message,
+        F: 'a + Fn(T) -> Message,
     {
         self.text_input = self.text_input.on_paste(InternalMessage::OnPaste);
         self.on_paste = Some(Box::new(callback));
@@ -348,58 +348,37 @@ where
                 InternalMessage::OnChange(value) => {
                     self.text = value;
 
-                    if self.text.ends_with('.') {
-                        self.text.push('0');
-                    }
-
-                    let value = match T::from_str(&self.text) {
-                        Ok(val) if self.value != val => {
-                            self.value = val.clone();
-                            Ok(val)
+                    if let Ok(value) = T::from_str(&self.text) {
+                        if self.value != value {
+                            self.value = value.clone();
+                            if let Some(on_change) = &self.on_change {
+                                shell.publish(on_change(value));
+                            }
                         }
-                        Ok(val) => Ok(val),
-                        Err(_) => Err(self.text.clone()),
                     };
-
-                    if let Some(on_change) = &self.on_change {
-                        shell.publish(on_change(value));
-                    }
-
                     shell.invalidate_layout();
                 }
                 InternalMessage::OnSubmit => {
                     if let Some(on_submit) = &self.on_submit {
-                        if self.text.ends_with('.') {
-                            self.text.push('0');
-                        }
-
                         let value = match T::from_str(&self.text) {
                             Ok(v) => Ok(v),
                             Err(_) => Err(self.text.clone()),
                         };
                         shell.publish(on_submit(value));
-                    }
+                    };
+                    shell.invalidate_layout();
                 }
                 InternalMessage::OnPaste(value) => {
                     self.text = value;
 
-                    if self.text.ends_with('.') {
-                        self.text.push('0');
-                    }
-
-                    let value = match T::from_str(&self.text) {
-                        Ok(val) if self.value != val => {
-                            self.value = val.clone();
-                            Ok(val)
+                    if let Ok(value) = T::from_str(&self.text) {
+                        if self.value != value {
+                            self.value = value.clone();
+                            if let Some(on_paste) = &self.on_paste {
+                                shell.publish(on_paste(value));
+                            }
                         }
-                        Ok(val) => Ok(val),
-                        Err(_) => Err(self.text.clone()),
                     };
-
-                    if let Some(on_paste) = &self.on_paste {
-                        shell.publish(on_paste(value));
-                    }
-
                     shell.invalidate_layout();
                 }
             }


### PR DESCRIPTION
I rewrote the logic of `NumberInput` to solve issues #308, #304, #299 and the problem with included and excluded bounds.

The `NumberInput` unlike the `TypedInput` never allows invalid entries.
People who try to implement a floating-point number should follow the way the `f32` is done; it can end with a `.`

I also added the support for any characters in the number, it just has to always be a valid number, regarding the `T::from_str` function.


I merge `content_width` and `width`. It seems to fix issues #286 and #278 