### PR TITLE
Add map support to GridRow

### DIFF
--- a/src/widget/grid/types.rs
+++ b/src/widget/grid/types.rs
@@ -247,10 +247,7 @@ where
     }
 
     /// Applies a transformation to the produced message of all the row's [`Element`].
-    pub fn map<B>(
-        self,
-        f: impl Fn(Message) -> B + 'a + Clone,
-    ) -> GridRow<'a, B, Theme, Renderer>
+    pub fn map<B>(self, f: impl Fn(Message) -> B + 'a + Clone) -> GridRow<'a, B, Theme, Renderer>
     where
         Message: 'a,
         Theme: 'a,

--- a/src/widget/grid/types.rs
+++ b/src/widget/grid/types.rs
@@ -245,4 +245,27 @@ where
         self.elements.push(element.into());
         self
     }
+
+    /// Applies a transformation to the produced message of all the row's [`Element`].
+    pub fn map<B>(
+        self,
+        f: impl Fn(Message) -> B + 'a + Clone,
+    ) -> GridRow<'a, B, Theme, Renderer>
+    where
+        Message: 'a,
+        Theme: 'a,
+        Renderer: renderer::Renderer + 'a,
+        B: 'a,
+    {
+        GridRow {
+            elements: self
+                .elements
+                .into_iter()
+                .map(|element| {
+                    let f = f.clone();
+                    element.map(move |message| f(message))
+                })
+                .collect(),
+        }
+    }
 }


### PR DESCRIPTION
I was in a situation I was returning a `GridRow` with a different `Message` type so I needed to map them to the type I needed. Since `GridRow` is basically a `Vec<Element>`, I just iterate the elements and call `Element::map` function.