### PR TITLE
drop_down overlay translation bugfix for #300

### DIFF
--- a/src/widget/drop_down.rs
+++ b/src/widget/drop_down.rs
@@ -214,7 +214,7 @@ where
             &self.alignment,
             &self.offset,
             layout.bounds(),
-            layout.position(),
+            layout.position() + translation,
         ))))
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/iced-rs/iced_aw/issues/300.

The overlay was not correctly positioned. I took a look at the code and found the solution in the tooltip window as described here https://github.com/iced-rs/iced_aw/issues/300#issuecomment-2692750200.

Since this is a bugfix and not a new feature I think it would be a good idea to get the fix in a patch crates.io release soon.