### PR TITLE
Fix WASM build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,8 +1210,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ default = [
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4.39", optional = true, features = ["wasmbind"] }
-getrandom = { version = "0.3.1" }
 iced_fonts = "0.1.1"
 itertools = { version = "0.14.0", optional = true }
 num-format = { version = "0.4.4", optional = true }
@@ -81,6 +80,7 @@ opt-level = 2
 [dev-dependencies]
 num-traits = "0.2.19"   # For widget_id_return example
 rand = "0.9.0"            # For wrap example
+getrandom = { version = "0.3.1", features = ["wasm_js"]}
 
 [dev-dependencies.iced]
 #git = "https://github.com/iced-rs/iced.git"


### PR DESCRIPTION
This is my first contribution here on github so please bear with me.

Compiling the iced_aw project and its examples for `wasm32-unknown-unknown` will result in this error: 

```
❯ cargo build --target wasm32-unknown-unknown
   Compiling getrandom v0.3.1
error: The wasm32-unknown-unknown targets are not supported by default; you may need to enable the "wasm_js" configuration flag. Note that enabling the `wasm_js` feature flag alone is insufficient. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /Users/miivers/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.1/src/backends.rs:159:9
    |
159 | /         compile_error!(
160 | |             "The wasm32-unknown-unknown targets are not supported by default; \
161 | |             you may need to enable the \"wasm_js\" configuration flag. Note \
162 | |             that enabling the `wasm_js` feature flag alone is insufficient. \
163 | |             For more information see: \
164 | |             https://docs.rs/getrandom/#webassembly-support"
165 | |         );
    | |_________^

error[E0425]: cannot find function `fill_inner` in module `backends`
  --> /Users/miivers/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.1/src/lib.rs:98:19
   |
98 |         backends::fill_inner(dest)?;
   |                   ^^^^^^^^^^ not found in `backends`

error[E0425]: cannot find function `inner_u32` in module `backends`
   --> /Users/miivers/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.1/src/lib.rs:127:15
    |
127 |     backends::inner_u32()
    |               ^^^^^^^^^ not found in `backends`
    |
help: consider importing this function
    |
32  + use crate::util::inner_u32;
    |
help: if you import `inner_u32`, refer to it directly
    |
127 -     backends::inner_u32()
127 +     inner_u32()
    |

error[E0425]: cannot find function `inner_u64` in module `backends`
   --> /Users/miivers/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/getrandom-0.3.1/src/lib.rs:141:15
    |
141 |     backends::inner_u64()
    |               ^^^^^^^^^ not found in `backends`
    |
help: consider importing this function
    |
32  + use crate::util::inner_u64;
    |
help: if you import `inner_u64`, refer to it directly
    |
141 -     backends::inner_u64()
141 +     inner_u64()
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `getrandom` (lib) due to 4 previous errors
```

This error is a result of missing support for the `os_rng` feature for the targe `wasm32-unknown-unknown`. This change configures `getrandom` to use the `wasm_js` backend for `getrandom` when compiling for `wasm32-unknown-unknown`