### PR TITLE
Add extend for Grid and GridRow

### DIFF
--- a/src/widget/grid/types.rs
+++ b/src/widget/grid/types.rs
@@ -67,6 +67,15 @@ where
         self
     }
 
+    /// Extends the [`Grid`] with the given children.
+    #[must_use]
+    pub fn extend(
+        self,
+        children: impl IntoIterator<Item = GridRow<'a, Message, Theme, Renderer>>,
+    ) -> Self {
+        children.into_iter().fold(self, Self::push)
+    }
+
     /// Sets the horizontal alignment of the widget within their cells. Default:
     /// [`Horizontal::Left`]
     #[must_use]
@@ -244,6 +253,15 @@ where
     {
         self.elements.push(element.into());
         self
+    }
+
+    /// Extends the [`GridRow`] with the given children.
+    #[must_use]
+    pub fn extend<E>(self, children: E) -> Self
+    where
+        E: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
+    {
+        children.into_iter().fold(self, Self::push)
     }
 
     /// Applies a transformation to the produced message of all the row's [`Element`].


### PR DESCRIPTION
In this PR I added the `extend` method for Grid and GridRow in the same way to what's already available for [Row](https://docs.iced.rs/iced/widget/struct.Row.html#method.extend) and [Column](https://docs.iced.rs/iced/widget/struct.Column.html#method.extend) in standard Iced widgets.

This allows to add children to the widget in a concise way.