### PR TITLE
Preserve ColorPicker state until it is reopened or externally modified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ required-features = ["card"]
 
 [[example]]
 name = "color_picker"
-required-features = ["color_picker"]
+required-features = ["color_picker", "iced/async-std"]
 
 [[example]]
 name = "date_picker"

--- a/examples/color_picker.rs
+++ b/examples/color_picker.rs
@@ -16,6 +16,7 @@ fn main() -> iced::Result {
         ColorPickerExample::view,
     )
     .font(iced_fonts::REQUIRED_FONT_BYTES)
+    .subscription(ColorPickerExample::subscription)
     .run()
 }
 
@@ -25,6 +26,7 @@ enum Message {
     ChooseColor,
     SubmitColor(Color),
     CancelColor,
+    Tick,
 }
 
 #[derive(Debug)]
@@ -54,6 +56,7 @@ impl ColorPickerExample {
             Message::CancelColor => {
                 self.show_picker = false;
             }
+            Message::Tick => {}
         }
     }
 
@@ -80,5 +83,13 @@ impl ColorPickerExample {
             .center_x(Length::Fill)
             .center_y(Length::Fill)
             .into()
+    }
+
+    fn subscription(&self) -> iced::Subscription<Message> {
+        // We're running this subscription in background to see if any unrelated
+        // rerenders can affect the implementation negatively.
+        // You do not need a background subscription to use color picker, this
+        // is simply test code.
+        iced::time::every(std::time::Duration::from_secs(1)).map(|_| Message::Tick)
     }
 }

--- a/src/widget/overlay/color_picker.rs
+++ b/src/widget/overlay/color_picker.rs
@@ -1678,6 +1678,8 @@ fn hex_text(
 pub struct State {
     /// The selected color of the [`ColorPickerOverlay`].
     pub(crate) color: Color,
+    /// The color used to initialize [`ColorPickerOverlay`].
+    pub(crate) initial_color: Color,
     /// The cache of the sat/value canvas of the [`ColorPickerOverlay`].
     pub(crate) sat_value_canvas_cache: canvas::Cache,
     /// The cache of the hue canvas of the [`ColorPickerOverlay`].
@@ -1696,21 +1698,34 @@ impl State {
     pub fn new(color: Color) -> Self {
         Self {
             color,
+            initial_color: color,
             ..Self::default()
         }
     }
 
-    /// Reset cached canvas when internal state is modified
-    pub fn clear_cache(&mut self) {
+    /// Reset cached canvas when internal state is modified.
+    ///
+    /// If the color has changed, empty all canvas caches
+    /// as they (unfortunately) do not depend on the picker state.
+    fn clear_cache(&mut self) {
         self.sat_value_canvas_cache.clear();
         self.hue_canvas_cache.clear();
+    }
+
+    /// Synchronize the color with an externally provided value.
+    pub(crate) fn force_synchronize(&mut self, color: Color) {
+        self.initial_color = color;
+        self.color = color;
+        self.clear_cache();
     }
 }
 
 impl Default for State {
     fn default() -> Self {
+        let default_color = Color::from_rgb(0.5, 0.25, 0.25);
         Self {
-            color: Color::from_rgb(0.5, 0.25, 0.25),
+            color: default_color,
+            initial_color: default_color,
             sat_value_canvas_cache: canvas::Cache::default(),
             hue_canvas_cache: canvas::Cache::default(),
             color_bar_dragged: ColorBarDragged::None,

--- a/src/widget/overlay/color_picker.rs
+++ b/src/widget/overlay/color_picker.rs
@@ -94,8 +94,7 @@ where
         class: &'a <Theme as style::color_picker::Catalog>::Class<'b>,
         tree: &'a mut Tree,
     ) -> Self {
-        //state.color_hex = color_picker::State::color_as_string(state.color);
-        let color_picker::State { overlay_state } = state;
+        let color_picker::State { overlay_state, .. } = state;
 
         ColorPickerOverlay {
             state: overlay_state,
@@ -126,6 +125,11 @@ where
     #[must_use]
     pub fn overlay(self) -> overlay::Element<'a, Message, Theme, Renderer> {
         overlay::Element::new(Box::new(self))
+    }
+
+    /// Force redraw all components if the internal state was changed
+    fn clear_cache(&mut self) {
+        self.state.clear_cache();
     }
 
     /// The event handling for the HSV color area.
@@ -425,8 +429,7 @@ where
                     self.state.focus = self.state.focus.next();
                 }
                 // TODO: maybe place this better
-                self.state.sat_value_canvas_cache.clear();
-                self.state.hue_canvas_cache.clear();
+                self.clear_cache();
             } else {
                 let sat_value_handle = |key_code: &keyboard::Key, color: &mut Color| {
                     let mut hsv_color: Hsv = (*color).into();
@@ -622,8 +625,7 @@ where
         shell: &mut Shell<Message>,
     ) -> event::Status {
         if event::Status::Captured == self.on_event_keyboard(&event) {
-            self.state.sat_value_canvas_cache.clear();
-            self.state.hue_canvas_cache.clear();
+            self.clear_cache();
             return event::Status::Captured;
         }
 
@@ -694,8 +696,7 @@ where
         if hsv_color_status == event::Status::Captured
             || rgba_color_status == event::Status::Captured
         {
-            self.state.sat_value_canvas_cache.clear();
-            self.state.hue_canvas_cache.clear();
+            self.clear_cache();
         }
 
         status
@@ -1078,7 +1079,6 @@ fn block1<Message, Theme>(
     let hsv_color_layout = layout;
 
     // ----------- HSV Color ----------------------
-    //let hsv_color_layout = block1_children.next().unwrap();
     hsv_color(
         renderer,
         color_picker,
@@ -1698,6 +1698,12 @@ impl State {
             color,
             ..Self::default()
         }
+    }
+
+    /// Reset cached canvas when internal state is modified
+    pub fn clear_cache(&mut self) {
+        self.sat_value_canvas_cache.clear();
+        self.hue_canvas_cache.clear();
     }
 }
 


### PR DESCRIPTION
Fixes #330. The `color` value maintained by the widget overlay will be retained until one of the following happens:

* Picker is reopened
* Picker is rendered with initial `color` value different from previous render

This means that any background subscriptions are safe, but explicitly changing the color while the overlay is open still works as intended and changes the color.

Screencast in progress, will post in comments - IDK how to add videos from GH CLI