### PR TITLE
Fix negative inputs and numpad handling by NumberInput

### DIFF
--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -48,7 +48,7 @@ impl NumberInputDemo {
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Number Input:");
-        let txt_minute = number_input(&self.value, -10..=10, Message::NumInpChanged)
+        let txt_minute = number_input(&self.value, -100..=100, Message::NumInpChanged)
             .style(number_input::number_input::primary)
             .on_submit(Message::NumInpSubmitted)
             .step(1);

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -10,12 +10,12 @@ use iced_aw::number_input;
 
 #[derive(Default, Debug)]
 pub struct NumberInputDemo {
-    value: u8,
+    value: i8,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    NumInpChanged(u8),
+    NumInpChanged(i8),
     NumInpSubmitted,
 }
 
@@ -48,7 +48,7 @@ impl NumberInputDemo {
 
     fn view(&self) -> Element<Message> {
         let lb_minute = Text::new("Number Input:");
-        let txt_minute = number_input(&self.value, 0..=10, Message::NumInpChanged)
+        let txt_minute = number_input(&self.value, -10..=10, Message::NumInpChanged)
             .style(number_input::number_input::primary)
             .on_submit(Message::NumInpSubmitted)
             .step(1);

--- a/examples/number_input.rs
+++ b/examples/number_input.rs
@@ -37,7 +37,7 @@ impl NumberInputDemo {
     fn update(&mut self, message: self::Message) {
         match message {
             Message::NumInpChanged(val) => {
-                println!("Value changed to {:?}", val);
+                println!("Value changed to {val:?}");
                 self.value = val;
             }
             Message::NumInpSubmitted => {
@@ -60,6 +60,7 @@ impl NumberInputDemo {
                 .push(lb_minute)
                 .push(txt_minute),
         )
+        .padding(10)
         .width(Length::Fill)
         .height(Length::Fill)
         .center_x(Length::Fill)

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -527,7 +527,6 @@ where
     }
 
     fn size(&self) -> Size<Length> {
-        // Size::new(self.width, Length::Shrink)
         Widget::size(&self.content)
     }
 
@@ -678,10 +677,11 @@ where
         };
 
         // Check if the value that would result from the input is valid and within bound
+        let supports_negative = self.min() < T::zero();
         let mut check_value = |value: &str| {
             if let Ok(value) = T::from_str(value) {
                 self.valid(&value)
-            } else if value.is_empty() {
+            } else if value.is_empty() || value == "-" && supports_negative {
                 self.value = T::zero();
                 true
             } else {
@@ -823,7 +823,7 @@ where
 
                                 event::Status::Captured
                             }
-                            // Mouvement of the cursor
+                            // Movement of the cursor
                             keyboard::Key::Named(
                                 keyboard::key::Named::ArrowLeft
                                 | keyboard::key::Named::ArrowRight

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -930,7 +930,7 @@ where
         for message in messages {
             match message {
                 InternalMessage::OnChange(value) => {
-                    if self.value != value {
+                    if self.value != value || self.value.is_zero() {
                         self.value = value.clone();
                         if let Some(on_change) = &self.on_change {
                             shell.publish(on_change(value));

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -777,7 +777,7 @@ where
                                             // including decimal separator but not including
                                             // minus sign.
                                             let _ =
-                                                value.drain((value.starts_with("-") as usize)..idx);
+                                                value.drain((value.starts_with('-').into())..idx);
                                         } else {
                                             let _ = value.remove(idx - 1);
                                         }
@@ -801,7 +801,7 @@ where
                                     }
                                     // We need the cursor not at the end
                                     cursor::State::Index(idx) if idx < value.len() => {
-                                        if idx == 0 && value.starts_with("-") {
+                                        if idx == 0 && value.starts_with('-') {
                                             let _ = value.remove(0);
                                         } else if modifiers.command() {
                                             // ctrl+del erases to the right,
@@ -935,7 +935,7 @@ where
                         if let Some(on_change) = &self.on_change {
                             shell.publish(on_change(value));
                         }
-                    };
+                    }
                     shell.invalidate_layout();
                 }
                 InternalMessage::OnSubmit(result) => {
@@ -947,7 +947,7 @@ where
                     }
                     if let Some(on_submit) = &self.on_submit {
                         shell.publish(on_submit.clone());
-                    };
+                    }
                     shell.invalidate_layout();
                 }
                 InternalMessage::OnPaste(value) => {
@@ -956,7 +956,7 @@ where
                         if let Some(on_paste) = &self.on_paste {
                             shell.publish(on_paste(value));
                         }
-                    };
+                    }
                     shell.invalidate_layout();
                 }
             }

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -780,7 +780,15 @@ where
                                     }
                                     // We need the cursor not at the start
                                     cursor::State::Index(idx) if idx > 0 => {
-                                        let _ = value.remove(idx - 1);
+                                        if modifiers.command() {
+                                            // ctrl+backspace erases to the left,
+                                            // including decimal separator but not including
+                                            // minus sign.
+                                            let _ =
+                                                value.drain((value.starts_with("-") as usize)..idx);
+                                        } else {
+                                            let _ = value.remove(idx - 1);
+                                        }
                                     }
                                     cursor::State::Index(_) => return event::Status::Ignored,
                                 }
@@ -805,7 +813,16 @@ where
                                     }
                                     // We need the cursor not at the end
                                     cursor::State::Index(idx) if idx < value.len() => {
-                                        let _ = value.remove(idx);
+                                        if idx == 0 && value.starts_with("-") {
+                                            let _ = value.remove(0);
+                                        } else if modifiers.command() {
+                                            // ctrl+del erases to the right,
+                                            // including decimal separator but not including
+                                            // minus sign.
+                                            let _ = value.drain(idx..);
+                                        } else {
+                                            let _ = value.remove(idx);
+                                        }
                                     }
                                     cursor::State::Index(_) => return event::Status::Ignored,
                                 }


### PR DESCRIPTION
Fixes #261. Fixes #333. 

* Allow lone minus sign in input, mapping it to 0 - the same way as for empty input.
* Fix too eager handling of numpad keys - numpad keys are misdetected by core framework (see https://github.com/iced-rs/iced/pull/2278), this PR aligns their behaviour with `TextInput`.