### PR TITLE
End selection_list hover highlight when cursor is outside bounds

### DIFF
--- a/src/widget/selection_list/list.rs
+++ b/src/widget/selection_list/list.rs
@@ -178,6 +178,8 @@ where
                 }
                 _ => {}
             }
+        } else {
+            list_state.hovered_option = None;
         }
 
         status


### PR DESCRIPTION
For a selection list, currently the hovered item highlight persists even when the cursor moves out of bounds, reproducible in the `selection_list` example.

This is solved by resetting the `hovered_option` state when the cursor is out of bounds.

Before:
![image](https://github.com/user-attachments/assets/c1daa2c2-f0da-48f0-acbf-f8524f9d80eb)

After:
![image](https://github.com/user-attachments/assets/aecf7f10-008f-4469-b832-e9b599fe7b9e)
