### PR TITLE
add CustomLayout widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ slide_bar = []
 drop_down = []
 sidebar = []
 labeled_frame = []
+custom_layout = ["iced/advanced"]
 
 default = [
     "badge",
@@ -58,6 +59,7 @@ default = [
     "menu",
     "sidebar",
     "labeled_frame",
+    "custom_layout",
 ]
 
 [dependencies]

--- a/examples/custom_layout.rs
+++ b/examples/custom_layout.rs
@@ -1,0 +1,89 @@
+/// Takes three child elements and places them in a row. The elements are placed left center right.
+/// The widget in the middle is placed in the center of the whole row rather than in the middle between the other two widgets.
+/// This means that the middle element is placed in the absolute center, not depending on the size of the other widgets.   
+pub fn three_split_row<'a, Message: 'a>(
+    left: impl Into<iced::Element<'a, Message>>,
+    middle: impl Into<iced::Element<'a, Message>>,
+    right: impl Into<iced::Element<'a, Message>>,
+    alignment: iced::alignment::Vertical,
+) -> iced::Element<'a, Message> {
+    iced_aw::widget::CustomLayout::new(
+        vec![left.into(), middle.into(), right.into()],
+        move |elements, states, renderer, limits| {
+            let mut middle_layout =
+                elements[1]
+                    .as_widget()
+                    .layout(&mut states[1], renderer, limits);
+            let side_limits = iced::advanced::layout::Limits::new(
+                (limits.min() - middle_layout.size()) * 0.5,
+                (limits.max() - middle_layout.size()) * 0.5,
+            );
+            let mut left_layout =
+                elements[0]
+                    .as_widget()
+                    .layout(&mut states[0], renderer, &side_limits);
+            let mut right_layout =
+                elements[2]
+                    .as_widget()
+                    .layout(&mut states[2], renderer, &side_limits);
+
+            let height = middle_layout
+                .size()
+                .height
+                .max(left_layout.size().height)
+                .max(right_layout.size().height);
+
+            left_layout = left_layout.clone().move_to((
+                0.0,
+                align_position(height, left_layout.size().height, alignment),
+            ));
+            middle_layout = middle_layout.clone().move_to((
+                align_position(
+                    limits.max().width,
+                    middle_layout.size().width,
+                    iced::Alignment::Center,
+                ),
+                align_position(height, middle_layout.size().height, alignment),
+            ));
+            right_layout = right_layout.clone().move_to((
+                align_position(
+                    limits.max().width,
+                    right_layout.size().width,
+                    iced::Alignment::End,
+                ),
+                align_position(height, right_layout.size().height, alignment),
+            ));
+
+            iced::advanced::layout::Node::with_children(
+                iced::Size::new(limits.max().width, height),
+                vec![left_layout, middle_layout, right_layout],
+            )
+        },
+    )
+    .width(iced::Fill)
+    .into()
+}
+
+fn align_position(limit: f32, size: f32, alignment: impl Into<iced::Alignment>) -> f32 {
+    match alignment.into() {
+        iced::Alignment::Start => 0.0,
+        iced::Alignment::Center => (limit - size) / 2.0,
+        iced::Alignment::End => limit - size,
+    }
+}
+
+fn view(_: &u8) -> iced::Element<'_, ()> {
+    three_split_row(
+        iced::widget::button("back"),
+        "center text",
+        iced::widget::button("next with some larger button"),
+        iced::alignment::Vertical::Center,
+    )
+}
+
+fn main() {
+    iced::application("labeled_frame example", |_: &mut u8, _: ()| {}, view)
+        .theme(|_| iced::Theme::Light)
+        .run()
+        .unwrap()
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -107,3 +107,8 @@ pub use sidebar::{Sidebar, SidebarWithContent};
 pub mod labeled_frame;
 #[cfg(feature = "labeled_frame")]
 pub use labeled_frame::LabeledFrame;
+
+#[cfg(feature = "custom_layout")]
+pub mod custom_layout;
+#[cfg(feature = "custom_layout")]
+pub use custom_layout::CustomLayout;

--- a/src/widget/custom_layout.rs
+++ b/src/widget/custom_layout.rs
@@ -1,0 +1,205 @@
+//! A container widget that allows you to specify the layouting of its children.
+
+use iced::advanced::Widget;
+
+#[allow(unused_imports)]
+pub use iced::advanced::{
+    layout::{Limits, Node},
+    widget::Tree,
+    Renderer,
+};
+
+type LayoutFn<'a, Message, Theme, Renderer> = Box<
+    dyn Fn(
+        &Vec<iced::Element<'a, Message, Theme, Renderer>>,
+        &mut Vec<Tree>,
+        &Renderer,
+        &Limits,
+    ) -> Node,
+>;
+
+/// A container widget that allows you to specify the layouting of its children.
+pub struct CustomLayout<'a, Message, Theme, Renderer> {
+    elements: Vec<iced::Element<'a, Message, Theme, Renderer>>,
+    width: iced::Length,
+    height: iced::Length,
+    layout: LayoutFn<'a, Message, Theme, Renderer>,
+}
+
+impl<'b, Message, Theme, Renderer: iced::advanced::Renderer>
+    CustomLayout<'b, Message, Theme, Renderer>
+{
+    /// Creates a new [`CustomLayout`]
+    pub fn new(
+        elements: Vec<iced::Element<'b, Message, Theme, Renderer>>,
+        layout: impl Fn(
+                &Vec<iced::Element<'b, Message, Theme, Renderer>>,
+                &mut Vec<Tree>,
+                &Renderer,
+                &Limits,
+            ) -> Node
+            + 'static,
+    ) -> Self {
+        Self {
+            elements,
+            width: iced::Shrink,
+            height: iced::Shrink,
+            layout: Box::new(layout),
+        }
+    }
+
+    /// Sets the width of the [`CustomLayout`]
+    pub fn width(mut self, length: impl Into<iced::Length>) -> Self {
+        self.width = length.into();
+        self
+    }
+
+    /// Sets the height of the [`CustomLayout`]
+    pub fn height(mut self, length: impl Into<iced::Length>) -> Self {
+        self.height = length.into();
+        self
+    }
+}
+
+impl<'b, Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, Renderer>
+    for CustomLayout<'b, Message, Theme, Renderer>
+{
+    fn size(&self) -> iced::Size<iced::Length> {
+        iced::Size::new(self.width, self.height)
+    }
+
+    fn layout(&self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
+        (self.layout)(&self.elements, &mut tree.children, renderer, limits)
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &iced::advanced::renderer::Style,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        viewport: &iced::Rectangle,
+    ) {
+        tree.children
+            .iter()
+            .zip(layout.children())
+            .zip(self.elements.iter())
+            .for_each(|((state, layout), element)| {
+                element
+                    .as_widget()
+                    .draw(state, renderer, theme, style, layout, cursor, viewport)
+            });
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        self.elements.iter().map(|x| Tree::new(x)).collect()
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(&self.elements);
+    }
+
+    fn operate(
+        &self,
+        state: &mut Tree,
+        layout: iced::advanced::Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn iced::advanced::widget::Operation,
+    ) {
+        state
+            .children
+            .iter_mut()
+            .zip(layout.children())
+            .zip(self.elements.iter())
+            .for_each(|((state, layout), element)| {
+                operation.container(None, layout.bounds(), &mut |operation| {
+                    element
+                        .as_widget()
+                        .operate(state, layout, renderer, operation);
+                });
+            });
+    }
+
+    fn on_event(
+        &mut self,
+        state: &mut Tree,
+        event: iced::Event,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn iced::advanced::Clipboard,
+        shell: &mut iced::advanced::Shell<'_, Message>,
+        viewport: &iced::Rectangle,
+    ) -> iced::advanced::graphics::core::event::Status {
+        state
+            .children
+            .iter_mut()
+            .zip(layout.children())
+            .zip(self.elements.iter_mut())
+            .map(|((state, layout), element)| {
+                element.as_widget_mut().on_event(
+                    state,
+                    event.clone(),
+                    layout,
+                    cursor,
+                    renderer,
+                    clipboard,
+                    shell,
+                    viewport,
+                )
+            })
+            .fold(iced::event::Status::Ignored, iced::event::Status::merge)
+    }
+
+    fn size_hint(&self) -> iced::Size<iced::Length> {
+        self.size()
+    }
+
+    fn overlay<'a>(
+        &'a mut self,
+        state: &'a mut Tree,
+        layout: iced::advanced::Layout<'_>,
+        renderer: &Renderer,
+        translation: iced::Vector,
+    ) -> Option<iced::advanced::overlay::Element<'a, Message, Theme, Renderer>> {
+        iced::advanced::overlay::from_children(
+            &mut self.elements,
+            state,
+            layout,
+            renderer,
+            translation,
+        )
+    }
+
+    fn mouse_interaction(
+        &self,
+        state: &Tree,
+        layout: iced::advanced::Layout<'_>,
+        cursor: iced::advanced::mouse::Cursor,
+        viewport: &iced::Rectangle,
+        renderer: &Renderer,
+    ) -> iced::advanced::mouse::Interaction {
+        self.elements
+            .iter()
+            .zip(&state.children)
+            .zip(layout.children())
+            .map(|((child, state), layout)| {
+                child
+                    .as_widget()
+                    .mouse_interaction(state, layout, cursor, viewport, renderer)
+            })
+            .max()
+            .unwrap_or_default()
+    }
+}
+
+impl<'b, Message: 'b, Theme: 'b, Renderer: iced::advanced::Renderer + 'b>
+    From<CustomLayout<'b, Message, Theme, Renderer>>
+    for iced::Element<'b, Message, Theme, Renderer>
+{
+    fn from(value: CustomLayout<'b, Message, Theme, Renderer>) -> Self {
+        iced::Element::new(value)
+    }
+}


### PR DESCRIPTION
This PR adds a widget that acts as a container but allows the user to define the layouting of its children. Basically a shorthand for a container widget with a replaceable layout function