### PR TITLE
Fix menu_bar! macro from needing the user of the macro to import menu::Item

### DIFF
--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -144,7 +144,7 @@ macro_rules! menu {
 #[macro_export]
 macro_rules! menu_bar {
     ($(($x:expr, $m:expr))+) => (
-        $crate::menu::MenuBar::new(vec![ $( Item::with_menu($x, $m) ),+ ])
+        $crate::menu::MenuBar::new(vec![ $( $crate::menu::Item::with_menu($x, $m) ),+ ])
     );
 }
 


### PR DESCRIPTION
This is a simple fix to the `menu_bar!` macro, the full path of the `Item` struct was not specified in the macro definition.

This leads to a `use of undeclared type Item` compile error when using the macro and not manually importing `menu::Item` like so: `use iced_aw::menu::Item;`

This just adds the prefix `$crate::menu::` before `Item` in the macro like what is done for the usage of the `menu::MenuBar` struct.