### PR TITLE
Update iced to #9d56b48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "iced"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_core",
  "iced_debug",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "iced_core"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "iced_debug"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_core",
  "iced_futures",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "iced_futures"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "futures",
  "iced_core",
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "iced_graphics"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "iced_program"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_graphics",
  "iced_runtime",
@@ -1458,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "iced_renderer"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
@@ -1470,7 +1470,7 @@ dependencies = [
 [[package]]
 name = "iced_runtime"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "bytes",
  "iced_core",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "iced_tiny_skia"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "bytemuck",
  "cosmic-text",
@@ -1499,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "iced_wgpu"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "bitflags 2.9.1",
  "bytemuck",
@@ -1519,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "iced_widget"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_renderer",
  "iced_runtime",
@@ -1533,7 +1533,7 @@ dependencies = [
 [[package]]
 name = "iced_winit"
 version = "0.14.0-dev"
-source = "git+https://github.com/iced-rs/iced.git?rev=c710591#c710591cc88022586ffb8770e8b138ce9acde04c"
+source = "git+https://github.com/iced-rs/iced.git?rev=9d56b48#9d56b488cc08b7365fb1839ed47ef92f3ff0fa36"
 dependencies = [
  "iced_debug",
  "iced_program",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["gui"]
 rust-version = "1.80"
 
 [features]
+# STK: revert to normal
 # default = ["selection_list"]
 default = ["full"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "iced_aw"
 version = "0.13.0-dev"
 authors = [
-    "Kaiden42 <gitlab@tinysn.com>",
-    "Andrew Wheeler <genusistimelord@gmail.com>",
+  "Kaiden42 <gitlab@tinysn.com>",
+  "Andrew Wheeler <genusistimelord@gmail.com>",
 ]
 edition = "2021"
 description = "Additional widgets for the Iced GUI library"
@@ -16,7 +16,8 @@ categories = ["gui"]
 rust-version = "1.80"
 
 [features]
-default = ["selection_list"]
+# default = ["selection_list"]
+default = ["full"]
 
 badge = []
 card = []
@@ -40,31 +41,31 @@ labeled_frame = []
 custom_layout = ["iced/advanced"]
 
 full = [
-    "badge",
-    "card",
-    "number_input",
-    "date_picker",
-    "color_picker",
-    "tab_bar",
-    "tabs",
-    "time_picker",
-    "slide_bar",
-    "wrap",
-    "selection_list",
-    "quad",
-    "context_menu",
-    "spinner",
-    "drop_down",
-    "menu",
-    "sidebar",
-    "labeled_frame",
-    "custom_layout",
+  "badge",
+  "card",
+  "number_input",
+  "date_picker",
+  "color_picker",
+  "tab_bar",
+  "tabs",
+  "time_picker",
+  "slide_bar",
+  "wrap",
+  "selection_list",
+  "quad",
+  "context_menu",
+  "spinner",
+  "drop_down",
+  "menu",
+  "sidebar",
+  "labeled_frame",
+  "custom_layout",
 ]
 
 [dev-dependencies]
-iced_aw = { path  = "./" }
+iced_aw = { path = "./" }
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
-rand = "0.9.2" # For wrap example
+rand = "0.9.2"                                            # For wrap example
 
 [dependencies.iced]
 version = "0.14.0-dev"
@@ -73,16 +74,19 @@ features = ["advanced"]
 [dependencies]
 cfg-if = "1.0"
 chrono = { version = "0.4.41", optional = true, features = ["wasmbind"] }
-iced_fonts = { version = "0.3.0-dev", features = ["advanced_text"], git = "https://github.com/Redhawk18/iced_fonts.git", rev = "31970b2" }
+iced_fonts = { version = "0.3.0-dev", features = [
+  "advanced_text",
+  "bootstrap",
+], git = "https://github.com/Redhawk18/iced_fonts.git", rev = "31970b2" }
 iced_widget = "0.14.0-dev" # Required for font generated from `iced_fonts`.
 num-format = { version = "0.4.4", optional = true }
 num-traits = { version = "0.2.19", optional = true }
 web-time = "1.1.0"
 
 [patch.crates-io]
-iced = { git = "https://github.com/iced-rs/iced.git", rev = "c710591" }
-iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "c710591" }
-iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "c710591" }
+iced = { git = "https://github.com/iced-rs/iced.git", rev = "9d56b48" }
+iced_core = { git = "https://github.com/iced-rs/iced.git", rev = "9d56b48" }
+iced_widget = { git = "https://github.com/iced-rs/iced.git", rev = "9d56b48" }
 
 [[example]]
 name = "badge"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ cfg-if = "1.0"
 chrono = { version = "0.4.41", optional = true, features = ["wasmbind"] }
 iced_fonts = { version = "0.3.0-dev", features = [
   "advanced_text",
-  "bootstrap",
 ], git = "https://github.com/Redhawk18/iced_fonts.git", rev = "31970b2" }
 iced_widget = "0.14.0-dev" # Required for font generated from `iced_fonts`.
 num-format = { version = "0.4.4", optional = true }

--- a/examples/custom_layout.rs
+++ b/examples/custom_layout.rs
@@ -82,8 +82,9 @@ fn view(_: &u8) -> iced::Element<'_, ()> {
 }
 
 fn main() {
-    iced::application("labeled_frame example", |_: &mut u8, _: ()| {}, view)
-        .theme(|_| iced::Theme::Light)
+    iced::application(|| 0, |_: &mut u8, _: ()| {}, view)
+        .title(|_: &u8| String::from("labeled_frame example"))
+        .theme(|_: &u8| iced::Theme::Light)
         .run()
         .unwrap()
 }

--- a/examples/labeled_frame.rs
+++ b/examples/labeled_frame.rs
@@ -8,7 +8,8 @@ fn view(_: &u8) -> iced::Element<'_, ()> {
 }
 
 fn main() {
-    iced::application("labeled_frame example", |_: &mut u8, _: ()| {}, view)
+    iced::application(|| 0, |_: &mut u8, _: ()| {}, view)
+        .title(|_: &u8| String::from("labeled_frame example"))
         .theme(|_| iced::Theme::Light)
         .run()
         .unwrap()

--- a/examples/slide_bar.rs
+++ b/examples/slide_bar.rs
@@ -7,15 +7,16 @@ use iced::{
     Element, Length,
 };
 
-use iced_aw::SlideBar;
+use iced_aw::{SlideBar, ICED_AW_FONT_BYTES};
 
 fn main() -> iced::Result {
     iced::application(
-        "Slider Bar example",
+        SlideBarExample::default,
         SlideBarExample::update,
         SlideBarExample::view,
     )
-    .font(iced_fonts::REQUIRED_FONT_BYTES)
+    .title(SlideBarExample::title)
+    .font(ICED_AW_FONT_BYTES)
     .run()
 }
 
@@ -30,6 +31,10 @@ struct SlideBarExample {
 }
 
 impl SlideBarExample {
+    fn title(&self) -> String {
+        String::from("Slider Bar example")
+    }
+
     fn update(&mut self, message: Message) {
         let Message::SliderBarChange(v) = message;
         self.value = v;

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -174,29 +174,29 @@ where
         }
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         state: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         cursor: Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
-    ) -> event::Status {
-        if event == Event::Mouse(mouse::Event::ButtonPressed(Button::Right)) {
+    ) {
+        if *event == Event::Mouse(mouse::Event::ButtonPressed(Button::Right)) {
             let bounds = layout.bounds();
 
             if cursor.is_over(bounds) {
                 let s: &mut State = state.state.downcast_mut();
                 s.cursor_position = cursor.position().unwrap_or_default();
                 s.show = !s.show;
-                return event::Status::Captured;
+                shell.capture_event();
             }
         }
 
-        self.underlay.as_widget_mut().on_event(
+        self.underlay.as_widget_mut().update(
             &mut state.children[0],
             event,
             layout,
@@ -228,8 +228,9 @@ where
     fn overlay<'b>(
         &'b mut self,
         state: &'b mut Tree,
-        layout: Layout<'_>,
+        layout: Layout<'b>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let s: &mut State = state.state.downcast_mut();
@@ -239,6 +240,7 @@ where
                 &mut state.children[0],
                 layout,
                 renderer,
+                viewport,
                 translation,
             );
         }

--- a/src/widget/custom_layout.rs
+++ b/src/widget/custom_layout.rs
@@ -1,6 +1,6 @@
 //! A container widget that allows you to specify the layouting of its children.
 
-use iced::advanced::Widget;
+use iced::{advanced::Widget, Rectangle};
 
 #[allow(unused_imports)]
 pub use iced::advanced::{
@@ -122,35 +122,46 @@ impl<'b, Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, The
             });
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         state: &mut Tree,
-        event: iced::Event,
+        event: &iced::Event,
         layout: iced::advanced::Layout<'_>,
         cursor: iced::advanced::mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn iced::advanced::Clipboard,
         shell: &mut iced::advanced::Shell<'_, Message>,
         viewport: &iced::Rectangle,
-    ) -> iced::advanced::graphics::core::event::Status {
-        state
+    ) {
+        // STK: clean this up if working
+        for ((state, layout), element) in state
             .children
             .iter_mut()
             .zip(layout.children())
             .zip(self.elements.iter_mut())
-            .map(|((state, layout), element)| {
-                element.as_widget_mut().on_event(
-                    state,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(iced::event::Status::Ignored, iced::event::Status::merge)
+        {
+            element.as_widget_mut().update(
+                state, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+        // state
+        //     .children
+        //     .iter_mut()
+        //     .zip(layout.children())
+        //     .zip(self.elements.iter_mut())
+        //     .map(|((state, layout), element)| {
+        //         element.as_widget_mut().on_event(
+        //             state,
+        //             event.clone(),
+        //             layout,
+        //             cursor,
+        //             renderer,
+        //             clipboard,
+        //             shell,
+        //             viewport,
+        //         )
+        //     })
+        //     .fold(iced::event::Status::Ignored, iced::event::Status::merge)
     }
 
     fn size_hint(&self) -> iced::Size<iced::Length> {
@@ -160,8 +171,9 @@ impl<'b, Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, The
     fn overlay<'a>(
         &'a mut self,
         state: &'a mut Tree,
-        layout: iced::advanced::Layout<'_>,
+        layout: iced::advanced::Layout<'a>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: iced::Vector,
     ) -> Option<iced::advanced::overlay::Element<'a, Message, Theme, Renderer>> {
         iced::advanced::overlay::from_children(
@@ -169,6 +181,7 @@ impl<'b, Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, The
             state,
             layout,
             renderer,
+            viewport,
             translation,
         )
     }

--- a/src/widget/labeled_frame.rs
+++ b/src/widget/labeled_frame.rs
@@ -2,6 +2,7 @@
 
 use iced::advanced;
 use iced::Pixels;
+use iced::Rectangle;
 
 /// The style of a [`LabeledFrame`]
 pub struct Style {
@@ -264,6 +265,7 @@ where
                     ..Default::default()
                 },
                 shadow: iced::Shadow::default(),
+                ..Default::default()
             },
             style.color,
         );
@@ -287,6 +289,7 @@ where
                     ..Default::default()
                 },
                 shadow: iced::Shadow::default(),
+                ..Default::default()
             },
             style.color,
         );
@@ -308,6 +311,7 @@ where
                     ..Default::default()
                 },
                 shadow: iced::Shadow::default(),
+                ..Default::default()
             },
             style.color,
         );
@@ -327,6 +331,7 @@ where
                     ..Default::default()
                 },
                 shadow: iced::Shadow::default(),
+                ..Default::default()
             },
             style.color,
         );
@@ -348,6 +353,7 @@ where
                     ..Default::default()
                 },
                 shadow: iced::Shadow::default(),
+                ..Default::default()
             },
             style.color,
         );
@@ -374,34 +380,40 @@ where
             .unwrap_or_default()
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         state: &mut advanced::widget::Tree,
-        event: iced::Event,
+        event: &iced::Event,
         layout: advanced::Layout<'_>,
         cursor: advanced::mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn advanced::Clipboard,
         shell: &mut advanced::Shell<'_, Message>,
         viewport: &iced::Rectangle,
-    ) -> advanced::graphics::core::event::Status {
-        [&mut self.title, &mut self.content]
+    ) {
+        // STK: clean up if working
+        // let status = [&mut self.title, &mut self.content]
+        //     .iter_mut()
+        //     .zip(&mut state.children)
+        //     .zip(layout.children())
+        //     .map(|((child, state), layout)| {
+        //         child.as_widget_mut().update(
+        //             state, event, layout, cursor, renderer, clipboard, shell, viewport,
+        //         )
+        //     })
+        //     .fold(iced::event::Status::Ignored, iced::event::Status::merge);
+        // if status == iced::event::Status::Captured {
+        //     shell.capture_event();
+        // }
+        for ((child, state), layout) in [&mut self.title, &mut self.content]
             .iter_mut()
             .zip(&mut state.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
-                child.as_widget_mut().on_event(
-                    state,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(iced::event::Status::Ignored, iced::event::Status::merge)
+        {
+            child.as_widget_mut().update(
+                state, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
     }
 
     fn operate(
@@ -427,8 +439,9 @@ where
     fn overlay<'b>(
         &'b mut self,
         state: &'b mut advanced::widget::Tree,
-        layout: advanced::Layout<'_>,
+        layout: advanced::Layout<'b>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: iced::Vector,
     ) -> Option<advanced::overlay::Element<'b, Message, Theme, Renderer>> {
         let children = vec![&mut self.title, &mut self.content]
@@ -438,7 +451,7 @@ where
             .filter_map(|((child, state), layout)| {
                 child
                     .as_widget_mut()
-                    .overlay(state, layout, renderer, translation)
+                    .overlay(state, layout, renderer, viewport, translation)
             })
             .collect::<Vec<_>>();
 

--- a/src/widget/menu/menu_bar.rs
+++ b/src/widget/menu/menu_bar.rs
@@ -177,37 +177,47 @@ where
         )
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         tree: &mut Tree,
-        event: event::Event,
+        event: &event::Event,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
-    ) -> event::Status {
-        use event::Status::*;
-
-        let status = self
+    ) {
+        // STK: cleanup
+        for ((item, tree), layout) in self
             .roots
             .iter_mut() // [Item...]
             .zip(tree.children.iter_mut()) // [item_tree...]
-            .zip(layout.children()) // [widget_node...]
-            .map(|((item, tree), layout)| {
-                item.on_event(
-                    tree,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(Ignored, event::Status::merge);
+            // [widget_node...]
+            .zip(layout.children())
+        {
+            item.update(
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+        // let status = self
+        //     .roots
+        //     .iter_mut() // [Item...]
+        //     .zip(tree.children.iter_mut()) // [item_tree...]
+        //     .zip(layout.children()) // [widget_node...]
+        //     .map(|((item, tree), layout)| {
+        //         item.on_event(
+        //             tree,
+        //             event.clone(),
+        //             layout,
+        //             cursor,
+        //             renderer,
+        //             clipboard,
+        //             shell,
+        //             viewport,
+        //         )
+        //     })
+        //     .fold(Ignored, event::Status::merge);
 
         let bar = tree.state.downcast_mut::<MenuBarState>();
         let bar_bounds = layout.bounds();
@@ -216,9 +226,7 @@ where
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if cursor.is_over(bar_bounds) {
                     bar.is_pressed = true;
-                    Captured
-                } else {
-                    Ignored
+                    shell.capture_event();
                 }
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
@@ -231,9 +239,7 @@ where
                             break;
                         }
                     }
-                    Captured
-                } else {
-                    Ignored
+                    shell.capture_event();
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
@@ -248,14 +254,11 @@ where
                     } else {
                         bar.open = false;
                     }
-                    Captured
-                } else {
-                    Ignored
+                    shell.capture_event();
                 }
             }
-            _ => Ignored,
+            _ => {}
         }
-        .merge(status)
     }
 
     fn operate(
@@ -281,16 +284,14 @@ where
         tree: &Tree,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
-        viewport: &Rectangle,
+        _viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
         self.roots
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
-            .map(|((item, tree), layout)| {
-                item.mouse_interaction(tree, layout, cursor, viewport, renderer)
-            })
+            .map(|((item, tree), layout)| item.mouse_interaction(tree, layout, cursor, renderer))
             .max()
             .unwrap_or_default()
     }
@@ -311,6 +312,7 @@ where
                 bounds: pad_rectangle(layout.bounds(), styling.bar_background_expand),
                 border: styling.bar_border,
                 shadow: styling.bar_shadow,
+                ..Default::default()
             },
             styling.bar_background,
         );
@@ -356,6 +358,7 @@ where
         tree: &'b mut Tree,
         layout: Layout<'_>,
         _renderer: &Renderer,
+        _viewport: &Rectangle,
         translation: iced::Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let state = tree.state.downcast_mut::<MenuBarState>();

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -304,7 +304,7 @@ where
     /// tree: Tree{ menu_state, \[item_tree...] }
     ///
     /// layout: Node{inf, \[ slice_node, prescroll, offset_bounds, check_bounds ]}
-    pub(super) fn on_event(
+    pub(super) fn update(
         &mut self,
         tree: &mut Tree,
         event: &Event,
@@ -315,9 +315,8 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
         scroll_speed: ScrollSpeed,
-    ) -> event::Status {
-        use event::Status::*;
-
+    ) {
+        // STK: cleanup
         let mut lc = layout.children();
         let slice_layout = lc.next().unwrap();
         let prescroll = lc.next().unwrap().bounds();
@@ -327,34 +326,41 @@ where
         let menu_state = tree.state.downcast_mut::<MenuState>();
         let slice = &menu_state.slice;
 
-        let status = self.items[slice.start_index..=slice.end_index] // [item...]
+        for ((item, tree), layout) in self.items[slice.start_index..=slice.end_index] // [item...]
             .iter_mut()
             .zip(tree.children[slice.start_index..=slice.end_index].iter_mut()) // [item_tree...]
-            .zip(slice_layout.children()) // [item_layout...]
-            .map(|((item, tree), layout)| {
-                item.on_event(
-                    tree,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(Ignored, event::Status::merge);
+            .zip(slice_layout.children())
+        {
+            item.update(
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+        // let status = self.items[slice.start_index..=slice.end_index] // [item...]
+        //     .iter_mut()
+        //     .zip(tree.children[slice.start_index..=slice.end_index].iter_mut()) // [item_tree...]
+        //     .zip(slice_layout.children()) // [item_layout...]
+        //     .map(|((item, tree), layout)| {
+        //         item.on_event(
+        //             tree,
+        //             event.clone(),
+        //             layout,
+        //             cursor,
+        //             renderer,
+        //             clipboard,
+        //             shell,
+        //             viewport,
+        //         )
+        //     })
+        //     .fold(Ignored, event::Status::merge);
 
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => {
                 if cursor.is_over(prescroll) {
                     menu_state.pressed = true;
                 }
-                Ignored
             }
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
                 menu_state.pressed = false;
-                Ignored
             }
             Event::Mouse(mouse::Event::WheelScrolled { delta }) => {
                 if cursor.is_over(prescroll) {
@@ -365,16 +371,13 @@ where
                         scroll_speed,
                         viewport.size(),
                     );
-                    Captured
+                    shell.capture_event();
                 } else if cursor.is_over(offset_bounds) || cursor.is_over(check_bounds) {
-                    Captured
-                } else {
-                    Ignored
+                    shell.capture_event();
                 }
             }
-            _ => Ignored,
+            _ => {}
         }
-        .merge(status)
     }
 
     pub(super) fn operate(
@@ -408,7 +411,7 @@ where
     pub(super) fn overlay<'b>(
         &'b mut self,
         tree: &'b mut Tree,
-        layout: Layout<'_>,
+        layout: Layout<'b>,
         renderer: &Renderer,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
@@ -441,7 +444,6 @@ where
         tree: &Tree,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
-        viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
         let mut lc = layout.children();
@@ -456,9 +458,7 @@ where
             .iter()
             .zip(tree.children[slice.start_index..=max_tree_slice].iter()) // [item_tree...]
             .zip(slice_layout.children()) // [item_layout...]
-            .map(|((item, tree), layout)| {
-                item.mouse_interaction(tree, layout, cursor, viewport, renderer)
-            })
+            .map(|((item, tree), layout)| item.mouse_interaction(tree, layout, cursor, renderer))
             .max()
             .unwrap_or_default()
     }
@@ -497,6 +497,7 @@ where
                     bounds: pad_rectangle,
                     border: theme_style.menu_border,
                     shadow: theme_style.menu_shadow,
+                    ..Default::default()
                 },
                 theme_style.menu_background,
             );
@@ -755,18 +756,18 @@ where
 
     /// tree: Tree{stateless, \[widget_tree, menu_tree]}
     ///
-    pub(super) fn on_event(
+    pub(super) fn update(
         &mut self,
         tree: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
-    ) -> event::Status {
-        self.item.as_widget_mut().on_event(
+    ) {
+        self.item.as_widget_mut().update(
             &mut tree.children[0],
             event,
             layout,
@@ -785,14 +786,14 @@ where
         tree: &Tree,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
-        viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
+        // STK: make sure layout.bounds() works out
         self.item.as_widget().mouse_interaction(
             &tree.children[0],
             layout,
             cursor,
-            viewport,
+            &layout.bounds(),
             renderer,
         )
     }
@@ -836,13 +837,18 @@ where
     pub(super) fn overlay<'b>(
         &'b mut self,
         tree: &'b mut Tree,
-        layout: Layout<'_>,
+        layout: Layout<'b>,
         renderer: &Renderer,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.item
-            .as_widget_mut()
-            .overlay(&mut tree.children[0], layout, renderer, translation)
+        // STK: ensure layout.bounds() works out here
+        self.item.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout,
+            renderer,
+            &layout.bounds(),
+            translation,
+        )
     }
 }
 

--- a/src/widget/overlay/context_menu.rs
+++ b/src/widget/overlay/context_menu.rs
@@ -14,7 +14,6 @@ use iced::{
         widget::Tree,
         Clipboard, Layout, Shell,
     },
-    event::Status,
     keyboard,
     mouse::{self, Cursor},
     touch, window, Border, Color, Element, Event, Point, Size,
@@ -172,7 +171,6 @@ where
                     self.state.show = false;
                     forward_event_to_children = false;
                     shell.capture_event();
-
                 }
             }
 
@@ -180,14 +178,10 @@ where
                 mouse::Button::Left | mouse::Button::Right,
             ))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                if cursor.is_over(layout_children.bounds()) {
-                    Status::Ignored
-                } else {
+                if !cursor.is_over(layout_children.bounds()) {
                     self.state.show = false;
-                    Status::Captured
+                    shell.capture_event();
                 }
-
-                shell.capture_event();
             }
 
             Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)) => {
@@ -195,7 +189,6 @@ where
                 self.state.show = false;
 
                 shell.capture_event();
-
             }
 
             Event::Window(window::Event::Resized { .. }) => {
@@ -205,8 +198,7 @@ where
             }
 
             _ => {}
-        };
-
+        }
 
         if forward_event_to_children {
             self.content.as_widget_mut().update(
@@ -218,7 +210,7 @@ where
                 clipboard,
                 shell,
                 &layout.bounds(),
-            )
+            );
         }
     }
 
@@ -229,6 +221,7 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
     ) -> mouse::Interaction {
+        // STK: make sure layout.bounds() works out
         let bounds = layout.bounds();
 
         self.content.as_widget().mouse_interaction(

--- a/src/widget/quad.rs
+++ b/src/widget/quad.rs
@@ -96,6 +96,7 @@ where
                         bounds,
                         border: self.bg_border,
                         shadow: self.bg_shadow,
+                        ..Default::default()
                     },
                     b,
                 );
@@ -105,6 +106,7 @@ where
                     bounds: self.inner_bounds.get_bounds(bounds),
                     border: self.quad_border,
                     shadow: self.quad_shadow,
+                    ..Default::default()
                 },
                 self.quad_color,
             );

--- a/src/widget/sidebar/column.rs
+++ b/src/widget/sidebar/column.rs
@@ -320,34 +320,45 @@ where
         });
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         tree: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
-    ) -> event::Status {
-        self.children
+    ) {
+        // STK: cleanup
+        for ((child, state), layout) in self
+            .children
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
-                child.as_widget_mut().on_event(
-                    state,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(event::Status::Ignored, event::Status::merge)
+        {
+            child.as_widget_mut().update(
+                state, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+        // self.children
+        //     .iter_mut()
+        //     .zip(&mut tree.children)
+        //     .zip(layout.children())
+        //     .map(|((child, state), layout)| {
+        //         child.as_widget_mut().on_event(
+        //             state,
+        //             event.clone(),
+        //             layout,
+        //             cursor,
+        //             renderer,
+        //             clipboard,
+        //             shell,
+        //             viewport,
+        //         )
+        //     })
+        //     .fold(event::Status::Ignored, event::Status::merge)
     }
 
     fn mouse_interaction(
@@ -408,11 +419,19 @@ where
     fn overlay<'b>(
         &'b mut self,
         tree: &'b mut Tree,
-        layout: Layout<'_>,
+        layout: Layout<'b>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        overlay::from_children(&mut self.children, tree, layout, renderer, translation)
+        overlay::from_children(
+            &mut self.children,
+            tree,
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
     }
 }
 

--- a/src/widget/sidebar/row.rs
+++ b/src/widget/sidebar/row.rs
@@ -325,34 +325,45 @@ where
         });
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         tree: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
-    ) -> event::Status {
-        self.children
+    ) {
+        // STK: clean up if working
+        for ((child, state), layout) in self
+            .children
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
-                child.as_widget_mut().on_event(
-                    state,
-                    event.clone(),
-                    layout,
-                    cursor,
-                    renderer,
-                    clipboard,
-                    shell,
-                    viewport,
-                )
-            })
-            .fold(event::Status::Ignored, event::Status::merge)
+        {
+            child.as_widget_mut().update(
+                state, event, layout, cursor, renderer, clipboard, shell, viewport,
+            )
+        }
+        // self.children
+        //     .iter_mut()
+        //     .zip(&mut tree.children)
+        //     .zip(layout.children())
+        //     .map(|((child, state), layout)| {
+        //         child.as_widget_mut().on_event(
+        //             state,
+        //             event.clone(),
+        //             layout,
+        //             cursor,
+        //             renderer,
+        //             clipboard,
+        //             shell,
+        //             viewport,
+        //         )
+        //     })
+        //     .fold(event::Status::Ignored, event::Status::merge)
     }
 
     fn mouse_interaction(
@@ -413,11 +424,19 @@ where
     fn overlay<'b>(
         &'b mut self,
         tree: &'b mut Tree,
-        layout: Layout<'_>,
+        layout: Layout<'b>,
         renderer: &Renderer,
+        viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        overlay::from_children(&mut self.children, tree, layout, renderer, translation)
+        overlay::from_children(
+            &mut self.children,
+            tree,
+            layout,
+            renderer,
+            viewport,
+            translation,
+        )
     }
 }
 

--- a/src/widget/sidebar/sidebar.rs
+++ b/src/widget/sidebar/sidebar.rs
@@ -8,9 +8,13 @@
 //! and it manages the displaying of the content.
 
 use super::column::FlushColumn;
-use crate::style::{
-    sidebar::{self, Catalog, Style},
-    Status, StyleFn,
+use crate::{
+    iced_aw_font,
+    style::{
+        sidebar::{self, Catalog, Style},
+        Status, StyleFn,
+    },
+    ICED_AW_FONT,
 };
 use iced::{
     advanced::{
@@ -32,7 +36,6 @@ use iced::{
     Alignment, Background, Border, Color, Element, Event, Font, Length, Padding, Pixels, Point,
     Rectangle, Shadow, Size, Vector,
 };
-use iced_fonts::{bootstrap::advanced_text::x, BOOTSTRAP_FONT};
 use std::marker::PhantomData;
 
 /// The default icon size.
@@ -676,7 +679,7 @@ where
                 &self.class,
                 i == self.get_active_tab_idx(),
                 cursor,
-                (self.font.unwrap_or(BOOTSTRAP_FONT), self.icon_size),
+                (self.font.unwrap_or(ICED_AW_FONT), self.icon_size),
                 (self.text_font.unwrap_or_default(), self.text_size),
                 self.close_size,
                 viewport,
@@ -834,7 +837,7 @@ fn draw_tab<Theme, Renderer>(
     {
         let cross_bounds = cross_layout.bounds();
         let is_mouse_over_cross = cursor.is_over(cross_bounds);
-        let (content, font, shaping) = x();
+        let (content, font, shaping) = iced_aw_font::advanced_text::cancel();
         renderer.fill_text(
             iced::advanced::text::Text {
                 content,

--- a/src/widget/slide_bar.rs
+++ b/src/widget/slide_bar.rs
@@ -165,17 +165,17 @@ where
         Node::new(size)
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         tree: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         _viewport: &Rectangle,
-    ) -> event::Status {
+    ) {
         update(
             &event,
             layout,
@@ -218,8 +218,7 @@ pub fn update<Message, T>(
     step: T,
     on_change: &dyn Fn(T) -> Message,
     on_release: &Option<Message>,
-) -> event::Status
-where
+) where
     T: Copy + Into<f64> + num_traits::FromPrimitive,
     Message: Clone,
 {
@@ -262,7 +261,7 @@ where
                 change(cursor_position);
                 state.is_dragging = true;
 
-                return event::Status::Captured;
+                shell.capture_event();
             }
         }
         Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
@@ -273,7 +272,7 @@ where
                 }
                 state.is_dragging = false;
 
-                return event::Status::Captured;
+                shell.capture_event();
             }
         }
         Event::Mouse(mouse::Event::CursorMoved { .. })
@@ -281,13 +280,11 @@ where
             if is_dragging {
                 let _ = cursor.position().map(change);
 
-                return event::Status::Captured;
+                shell.capture_event();
             }
         }
         _ => {}
     }
-
-    event::Status::Ignored
 }
 
 /// Draws a [`SlideBar`].
@@ -333,6 +330,7 @@ pub fn draw<T, R, Message>(
                     color: slider.border_color,
                 },
                 shadow: Shadow::default(),
+                ..Default::default()
             },
             background,
         );
@@ -348,6 +346,7 @@ pub fn draw<T, R, Message>(
                     color: Color::TRANSPARENT,
                 },
                 shadow: Shadow::default(),
+                ..Default::default()
             },
             slider.color,
         );

--- a/src/widget/spinner.rs
+++ b/src/widget/spinner.rs
@@ -194,7 +194,6 @@ where
                     state.t -= 1.0;
                 }
 
-
                 shell.request_redraw_at(window::RedrawRequest::At(
                     *now + Duration::from_millis(1000 / FRAMES_PER_SECOND),
                 ));

--- a/src/widget/spinner.rs
+++ b/src/widget/spinner.rs
@@ -98,6 +98,7 @@ fn fill_circle(
                     color: Color::TRANSPARENT,
                 },
                 shadow: Shadow::default(),
+                ..Default::default()
             },
             color,
         );
@@ -164,17 +165,17 @@ where
         })
     }
 
-    fn on_event(
+    fn update(
         &mut self,
         state: &mut Tree,
-        event: Event,
+        event: &Event,
         layout: Layout<'_>,
         _cursor: Cursor,
         _renderer: &Renderer,
         _clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,
         _viewport: &Rectangle,
-    ) -> Status {
+    ) {
         const FRAMES_PER_SECOND: u64 = 60;
 
         let bounds = layout.bounds();
@@ -182,7 +183,7 @@ where
         if let Event::Window(window::Event::RedrawRequested(now)) = event {
             if is_visible(&bounds) {
                 let state = state.state.downcast_mut::<SpinnerState>();
-                let duration = (now - state.last_update).as_secs_f32();
+                let duration = (*now - state.last_update).as_secs_f32();
                 let increment = if self.rate == Duration::ZERO {
                     0.0
                 } else {
@@ -195,16 +196,12 @@ where
                     state.t -= 1.0;
                 }
 
-                shell.request_redraw(window::RedrawRequest::At(
-                    now + Duration::from_millis(1000 / FRAMES_PER_SECOND),
-                ));
-                state.last_update = now;
+                shell.request_redraw_at(*now + Duration::from_millis(1000 / FRAMES_PER_SECOND));
+                state.last_update = *now;
 
-                return Status::Captured;
+                shell.capture_event();
             }
         }
-
-        Status::Ignored
     }
 }
 


### PR DESCRIPTION
Update iced to https://github.com/iced-rs/iced/commit/9d56b488cc08b7365fb1839ed47ef92f3ff0fa36

- [x] iced_fonts has no [REQUIRED_FONT](https://docs.rs/iced_fonts/latest/iced_fonts/constant.REQUIRED_FONT.html) anymore, which font should be used now? ~(I used `BOOTSTRAP_FONT` for now)~
- [x] iced added a `viewport` argument to the [Widget::overlay](https://docs.iced.rs/iced/advanced/trait.Widget.html#method.overlay) method, which is not present in [Overlay::overlay](https://docs.iced.rs/iced/advanced/trait.Overlay.html#method.overlay). ~I used `layout.bounds()` for now, but no idea if that's any good, need to look more into it.~ Seems to work well
- [ ] Test/fix all examples
    - [ ] `menu`
    - [ ] `number_input`
    - [ ] `selection_list`
    - [ ] `badge`
    - [ ] `widget_id_return`
    - [ ] `tabs`
    - [ ] `side_bar`
- [ ] Should the new [`snap` field on `Quad`](https://docs.iced.rs/iced/advanced/renderer/struct.Quad.html#structfield.snap) be configurable? I just made it `Default` for now
- [ ] Fix lints