### PR TITLE
Fix dropdown underland bounds detection when inside scrollable

### DIFF
--- a/src/widget/drop_down.rs
+++ b/src/widget/drop_down.rs
@@ -404,6 +404,13 @@ where
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<Message>,
     ) {
+        self.underlay_bounds = Rectangle {
+            x: self.position.x,
+            y: self.position.y,
+            width: self.underlay_bounds.width,
+            height: self.underlay_bounds.height,
+        };
+
         if let Some(on_dismiss) = self.on_dismiss {
             match &event {
                 Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {


### PR DESCRIPTION
Fixes #355 

This bug is also present on the branch for iced 0.13. Should I also fix that branch or do we consider it "abandoned" ?