### PR TITLE
split iced crate import into iced_core/iced_widget sub crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -1345,6 +1345,7 @@ dependencies = [
  "getrandom 0.3.3",
  "iced",
  "iced_aw",
+ "iced_core",
  "iced_fonts",
  "iced_widget",
  "num-format",
@@ -1682,9 +1683,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -2453,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -3235,9 +3236,9 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"
-version = "2.5.5"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec961601b32b6f5d14ae8dabd35ff2ff2e2c6cb4c0e6641845ff105abe96d958"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4160,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -4287,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.9.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
+checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -4311,7 +4312,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -4320,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.9.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
+checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4427,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.6.0"
+version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
 dependencies = [
  "endi",
  "enumflags2",
@@ -4442,9 +4443,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.6.0"
+version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4455,14 +4456,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
  "syn",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ default = ["full"]
 badge = []
 card = []
 date_picker = ["chrono"]
-color_picker = ["iced/canvas"]
+color_picker = ["iced_widget/canvas"]
 tab_bar = []
 tabs = ["tab_bar"]
-time_picker = ["chrono", "iced/canvas"]
+time_picker = ["chrono", "iced_widget/canvas"]
 wrap = []
 number_input = ["num-format", "num-traits", "typed_input"]
 typed_input = []
@@ -37,7 +37,7 @@ slide_bar = []
 drop_down = []
 sidebar = []
 labeled_frame = []
-custom_layout = ["iced/advanced"]
+custom_layout = []
 
 full = [
   "badge",
@@ -66,17 +66,19 @@ iced_aw = { path = "./" }
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
 rand = "0.9.2"                                            # For wrap example
 
-[dependencies.iced]
+[dev-dependencies.iced]
 version = "0.14.0-dev"
 features = ["advanced"]
 
 [dependencies]
+iced_core = "0.14.0-dev"
+iced_widget = "0.14.0-dev"
+
 cfg-if = "1.0"
 chrono = { version = "0.4.41", optional = true, features = ["wasmbind"] }
 iced_fonts = { version = "0.3.0-dev", features = [
   "advanced_text",
 ], git = "https://github.com/Redhawk18/iced_fonts.git", rev = "31970b2" }
-iced_widget = "0.14.0-dev" # Required for font generated from `iced_fonts`.
 num-format = { version = "0.4.4", optional = true }
 num-traits = { version = "0.2.19", optional = true }
 web-time = "1.1.0"

--- a/src/core/clock.rs
+++ b/src/core/clock.rs
@@ -1,6 +1,6 @@
 //! Helper functions for calculating the clock
 
-use iced::Point;
+use iced_core::Point;
 use std::fmt::Display;
 
 /// The size of the period on the clock based on the clock's size.
@@ -123,7 +123,7 @@ pub fn nearest_radius(
 
 #[cfg(test)]
 mod tests {
-    use iced::{Point, Vector};
+    use iced_core::{Point, Vector};
 
     use super::{circle_points, nearest_point, nearest_radius, NearestRadius};
 

--- a/src/core/color.rs
+++ b/src/core/color.rs
@@ -1,6 +1,6 @@
 //! Helper functions and structs for picking dates.
 
-use iced::Color;
+use iced_core::Color;
 
 /// A color in the HSV color space.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -99,7 +99,7 @@ impl From<Hsv> for Color {
 
 #[cfg(test)]
 mod tests {
-    use iced::Color;
+    use iced_core::Color;
 
     use super::Hsv;
 

--- a/src/core/offset.rs
+++ b/src/core/offset.rs
@@ -1,6 +1,6 @@
 //! Offset struct
 
-use iced::Point;
+use iced_core::Point;
 
 /// Represents an offset in a two-dimensional space.
 #[derive(Copy, Clone, Debug)]

--- a/src/core/overlay.rs
+++ b/src/core/overlay.rs
@@ -1,6 +1,6 @@
 //! Helper functions for overlays
 
-use iced::{advanced::layout, Point, Size};
+use iced_core::{layout, Point, Size};
 
 /// Trait containing functions for positioning of nodes.
 pub trait Position {

--- a/src/core/renderer.rs
+++ b/src/core/renderer.rs
@@ -1,6 +1,6 @@
 //! Helper struct for drawing
 
-use iced::{advanced::Layout, Point, Rectangle};
+use iced_core::{Layout, Point, Rectangle};
 
 /// Collection of all necessary data to draw a widget.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,6 @@ pub use widget as widgets;
 
 pub mod core;
 pub mod style;
-pub use iced::Element;
 pub use iced_fonts;
 
 /// Exports for all platforms that are not WASM32.
@@ -168,7 +167,7 @@ mod platform {
 #[doc(no_inline)]
 pub use platform::*;
 
-use iced::Font;
+use iced_core::Font;
 use iced_fonts::generate_icon_functions;
 
 /// Embedded font file. There a handfull of glyphs so no need to worry.

--- a/src/style/badge.rs
+++ b/src/style/badge.rs
@@ -2,7 +2,7 @@
 //!
 //! *This API requires the following crate features to be activated: badge*
 use super::{colors, Status, StyleFn};
-use iced::{theme::palette, Background, Color, Theme};
+use iced_core::{theme::palette, Background, Color, Theme};
 
 /// The style of a [`Badge`](crate::widget::badge::Badge).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/card.rs
+++ b/src/style/card.rs
@@ -3,7 +3,7 @@
 //! *This API requires the following crate features to be activated: card*
 
 use super::{colors, Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The appearance of a [`Card`](crate::widget::card::Card).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/color_picker.rs
+++ b/src/style/color_picker.rs
@@ -3,7 +3,7 @@
 //! *This API requires the following crate features to be activated: `color_picker`*
 
 use super::{Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The appearance of a [`ColorPicker`](crate::widget::ColorPicker).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/colors.rs
+++ b/src/style/colors.rs
@@ -5,7 +5,7 @@
 //! * [W3 Schools](https://www.w3schools.com/cssref/css_colors.asp)
 //! * [Corecoding](https://corecoding.com/utilities/rgb-or-hex-to-float.php)
 
-use iced::Color;
+use iced_core::Color;
 
 /// Primary <span style="color:dodgerblue">Color</span>.
 pub const PRIMARY: Color = DODGER_BLUE;

--- a/src/style/context_menu.rs
+++ b/src/style/context_menu.rs
@@ -2,7 +2,7 @@
 //!
 //! *This API requires the following crate features to be activated: badge*
 use super::{Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The style of a [`ContextMenu`](crate::widget::ContextMenu).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/date_picker.rs
+++ b/src/style/date_picker.rs
@@ -2,7 +2,7 @@
 //!
 //! *This API requires the following crate features to be activated: `date_picker`*
 use super::{Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The appearance of a [`DatePicker`](crate::widget::DatePicker).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/menu_bar.rs
+++ b/src/style/menu_bar.rs
@@ -1,6 +1,6 @@
 //! Change the appearance of menu bars and their menus.
 use super::{Status, StyleFn};
-use iced::{Background, Border, Color, Padding, Shadow, Theme, Vector};
+use iced_core::{Background, Border, Color, Padding, Shadow, Theme, Vector};
 
 /// The appearance of a menu bar and its menus.
 #[derive(Debug, Clone, Copy)]

--- a/src/style/number_input.rs
+++ b/src/style/number_input.rs
@@ -3,7 +3,8 @@
 //! *This API requires the following crate features to be activated: `number_input`*
 
 use super::{Status, StyleFn};
-use iced::{widget, Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
+use iced_widget::{container, text, text_input};
 
 /// The appearance of a [`NumberInput`](crate::widget::number_input::NumberInput).
 #[derive(Clone, Copy, Debug)]
@@ -49,12 +50,12 @@ impl Catalog for Theme {
 
 /// The Extended Catalog of a [`NumberInput`](crate::widget::number_input::NumberInput).
 pub trait ExtendedCatalog:
-    widget::text_input::Catalog + widget::container::Catalog + widget::text::Catalog + self::Catalog
+    text_input::Catalog + container::Catalog + text::Catalog + self::Catalog
 {
     /// The default class produced by the [`Catalog`].
     #[must_use]
-    fn default_input<'a>() -> <Self as widget::text_input::Catalog>::Class<'a> {
-        <Self as widget::text_input::Catalog>::default()
+    fn default_input<'a>() -> <Self as text_input::Catalog>::Class<'a> {
+        <Self as text_input::Catalog>::default()
     }
 
     /// The [`Style`] of a class with the given status.

--- a/src/style/selection_list.rs
+++ b/src/style/selection_list.rs
@@ -3,7 +3,7 @@
 //! *This API requires the following crate features to be activated: `selection_list`*
 
 use super::{Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The appearance of a menu.
 #[derive(Debug, Clone, Copy)]

--- a/src/style/sidebar.rs
+++ b/src/style/sidebar.rs
@@ -4,7 +4,7 @@
 //! *This API requires the following crate features to be activated: `sidebar`*
 
 use super::{Status, StyleFn};
-use iced::{border::Radius, Background, Color, Theme};
+use iced_core::{border::Radius, Background, Color, Theme};
 
 /// The appearance of a [`Sidebar`](crate::widget::sidebar::Sidebar).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/tab_bar.rs
+++ b/src/style/tab_bar.rs
@@ -7,7 +7,7 @@
 //! *This API requires the following crate features to be activated: `tab_bar`*
 
 use super::{Status, StyleFn};
-use iced::{border::Radius, Background, Color, Theme};
+use iced_core::{border::Radius, Background, Color, Theme};
 
 /// The appearance of a [`TabBar`](crate::widget::tab_bar::TabBar).
 #[derive(Clone, Copy, Debug)]

--- a/src/style/time_picker.rs
+++ b/src/style/time_picker.rs
@@ -3,7 +3,7 @@
 //! *This API requires the following crate features to be activated: `time_picker`*
 #![allow(clippy::doc_markdown)]
 use super::{Status, StyleFn};
-use iced::{Background, Color, Theme};
+use iced_core::{Background, Color, Theme};
 
 /// The style of a [`TimePicker`](crate::widget::TimePicker).
 #[derive(Clone, Copy, Debug)]

--- a/src/widget/badge.rs
+++ b/src/widget/badge.rs
@@ -2,16 +2,13 @@
 //!
 //! *This API requires the following crate features to be activated: badge*
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::Tree,
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    window, Alignment, Border, Color, Element, Event, Length, Padding, Point, Rectangle, Shadow,
-    Size,
+    renderer,
+    widget::Tree,
+    window, Alignment, Border, Clipboard, Color, Element, Event, Layout, Length, Padding, Point,
+    Rectangle, Shadow, Shell, Size, Widget,
 };
 
 pub use crate::style::{
@@ -26,7 +23,7 @@ const BORDER_RADIUS_RATIO: f32 = 34.0 / 15.0;
 ///
 /// # Example
 /// ```ignore
-/// # use iced::widget::Text;
+/// # use iced_widget::Text;
 /// # use iced_aw::Badge;
 /// #
 /// #[derive(Debug, Clone)]
@@ -36,7 +33,7 @@ const BORDER_RADIUS_RATIO: f32 = 34.0 / 15.0;
 /// let badge = Badge::<Message>::new(Text::new("Text"));
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct Badge<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct Badge<'a, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
     Renderer: renderer::Renderer,
     Theme: Catalog,

--- a/src/widget/card.rs
+++ b/src/widget/card.rs
@@ -7,21 +7,18 @@ pub use crate::style::{
     card::{Catalog, Style},
     status::{Status, StyleFn},
 };
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        text::LineHeight,
-        widget::{Operation, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::Vertical,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
+    overlay, renderer,
+    text::LineHeight,
     touch,
-    widget::text::Wrapping,
-    Alignment, Border, Color, Element, Event, Length, Padding, Pixels, Point, Rectangle, Shadow,
-    Size, Vector,
+    widget::{Operation, Tree},
+    Alignment, Border, Clipboard, Color, Element, Event, Layout, Length, Padding, Pixels, Point,
+    Rectangle, Shadow, Shell, Size, Vector, Widget,
 };
+use iced_widget::text::Wrapping;
 
 /// The default padding of a [`Card`].
 const DEFAULT_PADDING: Padding = Padding::new(10.0);
@@ -30,7 +27,7 @@ const DEFAULT_PADDING: Padding = Padding::new(10.0);
 ///
 /// # Example
 /// ```ignore
-/// # use iced::widget::Text;
+/// # use iced_widget::Text;
 /// # use iced_aw::Card;
 /// #
 /// #[derive(Debug, Clone)]
@@ -47,7 +44,7 @@ const DEFAULT_PADDING: Padding = Padding::new(10.0);
 ///
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct Card<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct Card<'a, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
     Renderer: renderer::Renderer,
     Theme: Catalog,
@@ -225,7 +222,7 @@ impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for Card<'a, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     fn children(&self) -> Vec<Tree> {
@@ -606,7 +603,7 @@ where
         renderer: &Renderer,
         viewport: &Rectangle,
         translation: Vector,
-    ) -> Option<iced::advanced::overlay::Element<'b, Message, Theme, Renderer>> {
+    ) -> Option<iced_core::overlay::Element<'b, Message, Theme, Renderer>> {
         let mut children = vec![&mut self.head, &mut self.body];
         if let Some(foot) = &mut self.foot {
             children.push(foot);
@@ -649,7 +646,7 @@ fn head_node<Message, Theme, Renderer>(
     tree: &mut Tree,
 ) -> Node
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
 {
     let header_size = head.as_widget().size();
 
@@ -779,7 +776,7 @@ fn draw_head<Message, Theme, Renderer>(
     close_size: Option<f32>,
     is_mouse_over_close: bool,
 ) where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     let mut head_children = layout.children();
@@ -845,7 +842,7 @@ fn draw_head<Message, Theme, Renderer>(
         let (content, font, shaping) = cancel();
 
         renderer.fill_text(
-            iced::advanced::text::Text {
+            iced_core::text::Text {
                 content,
                 bounds: Size::new(close_bounds.width, close_bounds.height),
                 size: Pixels(
@@ -878,7 +875,7 @@ fn draw_body<Message, Theme, Renderer>(
     theme: &Theme,
     style: &Style,
 ) where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     let mut body_children = layout.children();
@@ -928,7 +925,7 @@ fn draw_foot<Message, Theme, Renderer>(
     theme: &Theme,
     style: &Style,
 ) where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     let mut foot_children = layout.children();
@@ -971,7 +968,7 @@ fn draw_foot<Message, Theme, Renderer>(
 impl<'a, Message, Theme, Renderer> From<Card<'a, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog,
     Message: Clone + 'a,
 {

--- a/src/widget/color_picker.rs
+++ b/src/widget/color_picker.rs
@@ -8,23 +8,14 @@ use super::overlay::color_picker::{
     self, ColorBarDragged, ColorPickerOverlay, ColorPickerOverlayButtons,
 };
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::tree::{self, Tag, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    Color,
-    Element,
-    Event,
-    Length,
-    Point,
-    Rectangle,
-    Renderer, // the actual type
-    Vector,
+    overlay, renderer,
+    widget::tree::{self, Tag, Tree},
+    Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Shell, Vector, Widget,
 };
+use iced_widget::Renderer;
 
 pub use crate::style::{self, color_picker::Style};
 
@@ -53,10 +44,10 @@ pub use crate::style::{self, color_picker::Style};
 /// );
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct ColorPicker<'a, Message, Theme = iced::Theme>
+pub struct ColorPicker<'a, Message, Theme = iced_widget::Theme>
 where
     Message: Clone,
-    Theme: style::color_picker::Catalog + iced::widget::button::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog,
 {
     /// Show the picker.
     show_picker: bool,
@@ -79,8 +70,8 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     /// Creates a new [`ColorPicker`] wrapping around the given underlay.
     ///
@@ -179,8 +170,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     fn tag(&self) -> Tag {
         Tag::of::<State>()
@@ -202,7 +193,7 @@ where
         tree.diff_children(&[&self.underlay, &self.overlay_state]);
     }
 
-    fn size(&self) -> iced::Size<Length> {
+    fn size(&self) -> iced_core::Size<Length> {
         self.underlay.as_widget().size()
     }
 
@@ -317,8 +308,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     fn from(color_picker: ColorPicker<'a, Message, Theme>) -> Self {
         Element::new(color_picker)

--- a/src/widget/common.rs
+++ b/src/widget/common.rs
@@ -1,7 +1,7 @@
 //! Common types for reuse.
 //!
 
-use iced::{Padding, Rectangle};
+use iced_core::{Padding, Rectangle};
 
 /// Methods for creating inner bounds
 #[allow(missing_debug_implementations)]

--- a/src/widget/context_menu.rs
+++ b/src/widget/context_menu.rs
@@ -1,14 +1,11 @@
 //! A context menu for showing actions on right click.
 //!
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::{tree, Operation, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Button, Cursor},
-    Element, Event, Length, Point, Rectangle, Vector,
+    overlay, renderer,
+    widget::{tree, Operation, Tree},
+    Clipboard, Element, Event, Layout, Length, Point, Rectangle, Shell, Vector, Widget,
 };
 
 pub use crate::style::{
@@ -23,7 +20,7 @@ use crate::widget::overlay::ContextMenuOverlay;
 ///
 /// # Example
 /// ```ignore
-/// # use iced::widget::{Text, Button};
+/// # use iced_widget::{Text, Button};
 /// # use iced_aw::ContextMenu;
 /// #
 /// #[derive(Debug, Clone)]
@@ -39,8 +36,13 @@ use crate::widget::overlay::ContextMenuOverlay;
 /// );
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct ContextMenu<'a, Overlay, Message, Theme = iced::Theme, Renderer = iced::Renderer>
-where
+pub struct ContextMenu<
+    'a,
+    Overlay,
+    Message,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> where
     Overlay: Fn() -> Element<'a, Message, Theme, Renderer>,
     Message: Clone,
     Renderer: renderer::Renderer,
@@ -103,7 +105,7 @@ where
     Renderer: 'a + renderer::Renderer,
     Theme: Catalog,
 {
-    fn size(&self) -> iced::Size<Length> {
+    fn size(&self) -> iced_core::Size<Length> {
         self.underlay.as_widget().size()
     }
 

--- a/src/widget/custom_layout.rs
+++ b/src/widget/custom_layout.rs
@@ -1,9 +1,9 @@
 //! A container widget that allows you to specify the layout of its children.
 
-use iced::{advanced::Widget, Rectangle};
+use iced_core::{Length, Rectangle, Widget};
 
 #[allow(unused_imports)]
-pub use iced::advanced::{
+pub use iced_core::{
     layout::{Limits, Node},
     widget::Tree,
     Renderer,
@@ -11,7 +11,7 @@ pub use iced::advanced::{
 
 type LayoutFn<'a, Message, Theme, Renderer> = Box<
     dyn Fn(
-        &mut Vec<iced::Element<'a, Message, Theme, Renderer>>,
+        &mut Vec<iced_core::Element<'a, Message, Theme, Renderer>>,
         &mut Vec<Tree>,
         &Renderer,
         &Limits,
@@ -20,20 +20,18 @@ type LayoutFn<'a, Message, Theme, Renderer> = Box<
 
 /// A container widget that allows you to specify the layout of its children.
 pub struct CustomLayout<'a, Message, Theme, Renderer> {
-    elements: Vec<iced::Element<'a, Message, Theme, Renderer>>,
-    width: iced::Length,
-    height: iced::Length,
+    elements: Vec<iced_core::Element<'a, Message, Theme, Renderer>>,
+    width: Length,
+    height: Length,
     layout: LayoutFn<'a, Message, Theme, Renderer>,
 }
 
-impl<'b, Message, Theme, Renderer: iced::advanced::Renderer>
-    CustomLayout<'b, Message, Theme, Renderer>
-{
+impl<'b, Message, Theme, Renderer: iced_core::Renderer> CustomLayout<'b, Message, Theme, Renderer> {
     /// Creates a new [`CustomLayout`]
     pub fn new(
-        elements: Vec<iced::Element<'b, Message, Theme, Renderer>>,
+        elements: Vec<iced_core::Element<'b, Message, Theme, Renderer>>,
         layout: impl Fn(
-                &mut Vec<iced::Element<'b, Message, Theme, Renderer>>,
+                &mut Vec<iced_core::Element<'b, Message, Theme, Renderer>>,
                 &mut Vec<Tree>,
                 &Renderer,
                 &Limits,
@@ -42,32 +40,32 @@ impl<'b, Message, Theme, Renderer: iced::advanced::Renderer>
     ) -> Self {
         Self {
             elements,
-            width: iced::Shrink,
-            height: iced::Shrink,
+            width: Length::Shrink,
+            height: Length::Shrink,
             layout: Box::new(layout),
         }
     }
 
     /// Sets the width of the [`CustomLayout`]
     #[must_use]
-    pub fn width(mut self, length: impl Into<iced::Length>) -> Self {
+    pub fn width(mut self, length: impl Into<Length>) -> Self {
         self.width = length.into();
         self
     }
 
     /// Sets the height of the [`CustomLayout`]
     #[must_use]
-    pub fn height(mut self, length: impl Into<iced::Length>) -> Self {
+    pub fn height(mut self, length: impl Into<Length>) -> Self {
         self.height = length.into();
         self
     }
 }
 
-impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, Renderer>
+impl<Message, Theme, Renderer: iced_core::Renderer> Widget<Message, Theme, Renderer>
     for CustomLayout<'_, Message, Theme, Renderer>
 {
-    fn size(&self) -> iced::Size<iced::Length> {
-        iced::Size::new(self.width, self.height)
+    fn size(&self) -> iced_core::Size<Length> {
+        iced_core::Size::new(self.width, self.height)
     }
 
     fn layout(&mut self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
@@ -79,10 +77,10 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
         tree: &Tree,
         renderer: &mut Renderer,
         theme: &Theme,
-        style: &iced::advanced::renderer::Style,
-        layout: iced::advanced::Layout<'_>,
-        cursor: iced::advanced::mouse::Cursor,
-        viewport: &iced::Rectangle,
+        style: &iced_core::renderer::Style,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
+        viewport: &iced_core::Rectangle,
     ) {
         tree.children
             .iter()
@@ -106,9 +104,9 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
     fn operate(
         &mut self,
         state: &mut Tree,
-        layout: iced::advanced::Layout<'_>,
+        layout: iced_core::Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn iced::advanced::widget::Operation,
+        operation: &mut dyn iced_core::widget::Operation,
     ) {
         state
             .children
@@ -127,13 +125,13 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
     fn update(
         &mut self,
         state: &mut Tree,
-        event: &iced::Event,
-        layout: iced::advanced::Layout<'_>,
-        cursor: iced::advanced::mouse::Cursor,
+        event: &iced_core::Event,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
         renderer: &Renderer,
-        clipboard: &mut dyn iced::advanced::Clipboard,
-        shell: &mut iced::advanced::Shell<'_, Message>,
-        viewport: &iced::Rectangle,
+        clipboard: &mut dyn iced_core::Clipboard,
+        shell: &mut iced_core::Shell<'_, Message>,
+        viewport: &iced_core::Rectangle,
     ) {
         for ((state, layout), element) in state
             .children
@@ -147,19 +145,19 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
         }
     }
 
-    fn size_hint(&self) -> iced::Size<iced::Length> {
+    fn size_hint(&self) -> iced_core::Size<Length> {
         self.size()
     }
 
     fn overlay<'a>(
         &'a mut self,
         state: &'a mut Tree,
-        layout: iced::advanced::Layout<'a>,
+        layout: iced_core::Layout<'a>,
         renderer: &Renderer,
         viewport: &Rectangle,
-        translation: iced::Vector,
-    ) -> Option<iced::advanced::overlay::Element<'a, Message, Theme, Renderer>> {
-        iced::advanced::overlay::from_children(
+        translation: iced_core::Vector,
+    ) -> Option<iced_core::overlay::Element<'a, Message, Theme, Renderer>> {
+        iced_core::overlay::from_children(
             &mut self.elements,
             state,
             layout,
@@ -172,11 +170,11 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
     fn mouse_interaction(
         &self,
         state: &Tree,
-        layout: iced::advanced::Layout<'_>,
-        cursor: iced::advanced::mouse::Cursor,
-        viewport: &iced::Rectangle,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
+        viewport: &iced_core::Rectangle,
         renderer: &Renderer,
-    ) -> iced::advanced::mouse::Interaction {
+    ) -> iced_core::mouse::Interaction {
         self.elements
             .iter()
             .zip(&state.children)
@@ -191,11 +189,11 @@ impl<Message, Theme, Renderer: iced::advanced::Renderer> Widget<Message, Theme, 
     }
 }
 
-impl<'b, Message: 'b, Theme: 'b, Renderer: iced::advanced::Renderer + 'b>
+impl<'b, Message: 'b, Theme: 'b, Renderer: iced_core::Renderer + 'b>
     From<CustomLayout<'b, Message, Theme, Renderer>>
-    for iced::Element<'b, Message, Theme, Renderer>
+    for iced_core::Element<'b, Message, Theme, Renderer>
 {
     fn from(value: CustomLayout<'b, Message, Theme, Renderer>) -> Self {
-        iced::Element::new(value)
+        iced_core::Element::new(value)
     }
 }

--- a/src/widget/date_picker.rs
+++ b/src/widget/date_picker.rs
@@ -5,28 +5,19 @@
 use super::overlay::date_picker::{self, DatePickerOverlay, DatePickerOverlayButtons};
 
 use chrono::Local;
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        text::Renderer as _,
-        widget::{
-            self,
-            tree::{Tag, Tree},
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    Element,
-    Event,
-    Length,
-    Pixels,
-    Point,
-    Rectangle,
-    Renderer, // the actual type
-    Size,
-    Vector,
+    renderer,
+    text::Renderer as _,
+    widget::{
+        self,
+        tree::{Tag, Tree},
+    },
+    Clipboard, Element, Event, Layout, Length, Pixels, Point, Rectangle, Shell, Size, Vector,
+    Widget,
 };
+use iced_widget::Renderer;
 
 pub use crate::{
     core::date::Date,
@@ -39,7 +30,7 @@ pub use crate::{
 /// # Example
 /// ```ignore
 /// # use iced_aw::DatePicker;
-/// # use iced::widget::{button, Button, Text};
+/// # use iced_widget::{button, Button, Text};
 /// #
 /// #[derive(Clone, Debug)]
 /// enum Message {
@@ -61,7 +52,7 @@ pub use crate::{
 pub struct DatePicker<'a, Message, Theme>
 where
     Message: Clone,
-    Theme: crate::style::date_picker::Catalog + iced::widget::button::Catalog,
+    Theme: crate::style::date_picker::Catalog + iced_widget::button::Catalog,
 {
     /// Show the picker.
     show_picker: bool,
@@ -87,9 +78,9 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
 {
     /// Creates a new [`DatePicker`] wrapping around the given underlay.
     ///
@@ -188,9 +179,9 @@ impl<Message, Theme> Widget<Message, Theme, Renderer> for DatePicker<'_, Message
 where
     Message: 'static + Clone,
     Theme: crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
 {
     fn tag(&self) -> Tag {
         Tag::of::<State>()
@@ -286,7 +277,7 @@ where
         renderer: &Renderer,
         viewport: &Rectangle,
         translation: Vector,
-    ) -> Option<iced::overlay::Element<'b, Message, Theme, Renderer>> {
+    ) -> Option<iced_core::overlay::Element<'b, Message, Theme, Renderer>> {
         let picker_state: &mut State = tree.state.downcast_mut();
 
         if !self.show_picker {
@@ -324,9 +315,9 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
 {
     fn from(date_picker: DatePicker<'a, Message, Theme>) -> Self {
         Element::new(date_picker)

--- a/src/widget/drop_down.rs
+++ b/src/widget/drop_down.rs
@@ -2,22 +2,19 @@
 //!
 //! *This API requires the following crate features to be activated: `drop_down`*
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::{Operation, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     keyboard::{self, key::Named},
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch, Element, Event, Length, Point, Rectangle, Size, Vector,
+    overlay, renderer, touch,
+    widget::{Operation, Tree},
+    Clipboard, Element, Event, Layout, Length, Point, Rectangle, Shell, Size, Vector, Widget,
 };
 
 pub use crate::core::{alignment::Alignment, offset::Offset};
 
 /// Customizable drop down menu widget
-pub struct DropDown<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct DropDown<'a, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
     Message: Clone,
     Renderer: renderer::Renderer,
@@ -232,8 +229,13 @@ where
     }
 }
 
-struct DropDownOverlay<'a, 'b, Message, Theme = iced::Theme, Renderer = iced::Renderer>
-where
+struct DropDownOverlay<
+    'a,
+    'b,
+    Message,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> where
     Message: Clone,
 {
     state: &'b mut Tree,

--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -4,7 +4,7 @@
 #[cfg(feature = "selection_list")]
 use crate::style::{Status, StyleFn};
 #[allow(unused_imports)]
-use iced::{self, advanced::renderer, Color, Element, Padding};
+use iced_core::{self, renderer, Color, Element, Padding};
 
 #[cfg(feature = "number_input")]
 use num_traits::bounds::Bounded;
@@ -155,7 +155,7 @@ where
 pub fn color_picker<'a, Message, Theme, F>(
     show_picker: bool,
     color: Color,
-    underlay: impl Into<Element<'a, Message, Theme, iced::Renderer>>,
+    underlay: impl Into<Element<'a, Message, Theme, iced_widget::Renderer>>,
     on_cancel: Message,
     on_submit: F,
 ) -> crate::ColorPicker<'a, Message, Theme>
@@ -163,8 +163,8 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
     F: 'static + Fn(Color) -> Message,
 {
     crate::ColorPicker::new(show_picker, color, underlay, on_cancel, on_submit)
@@ -177,7 +177,7 @@ where
 pub fn date_picker<'a, Message, Theme, F>(
     show_picker: bool,
     date: impl Into<crate::core::date::Date>,
-    underlay: impl Into<Element<'a, Message, Theme, iced::Renderer>>,
+    underlay: impl Into<Element<'a, Message, Theme, iced_widget::Renderer>>,
     on_cancel: Message,
     on_submit: F,
 ) -> crate::DatePicker<'a, Message, Theme>
@@ -185,9 +185,9 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
     F: 'static + Fn(crate::core::date::Date) -> Message,
 {
     crate::DatePicker::new(show_picker, date, underlay, on_cancel, on_submit)
@@ -208,9 +208,9 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::time_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
-    U: Into<Element<'a, Message, Theme, iced::Renderer>>,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
+    U: Into<Element<'a, Message, Theme, iced_widget::Renderer>>,
     F: 'static + Fn(crate::core::time::Time) -> Message,
 {
     crate::TimePicker::new(show_picker, time, underlay, on_cancel, on_submit)
@@ -256,7 +256,7 @@ pub fn number_input<'a, T, Message, Theme, Renderer, F>(
 ) -> crate::NumberInput<'a, T, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
-    Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: crate::style::number_input::ExtendedCatalog,
     F: 'static + Fn(T) -> Message + Copy,
     T: 'static
@@ -282,8 +282,8 @@ pub fn typed_input<'a, T, Message, Theme, Renderer, F>(
 ) -> crate::TypedInput<'a, T, Message, Theme, Renderer>
 where
     Message: Clone,
-    Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
-    Theme: iced::widget::text_input::Catalog,
+    Renderer: iced_core::text::Renderer<Font = iced_core::Font>,
+    Theme: iced_widget::text_input::Catalog,
     F: 'static + Fn(T) -> Message + Copy,
     T: 'static + std::fmt::Display + std::str::FromStr + Clone,
 {
@@ -302,15 +302,15 @@ pub fn selection_list_with<'a, T, Message, Theme, Renderer>(
     padding: impl Into<Padding>,
     style: impl Fn(&Theme, Status) -> crate::style::selection_list::Style + 'a + Clone,
     selected: Option<usize>,
-    font: iced::Font,
+    font: iced_core::Font,
 ) -> crate::SelectionList<'a, T, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a
         + crate::style::selection_list::Catalog
-        + iced::widget::container::Catalog
-        + iced::widget::scrollable::Catalog,
+        + iced_widget::container::Catalog
+        + iced_widget::scrollable::Catalog,
     T: Clone + Display + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
     <Theme as crate::style::selection_list::Catalog>::Class<'a>:
@@ -338,11 +338,11 @@ pub fn selection_list<'a, T, Message, Theme, Renderer>(
 ) -> crate::SelectionList<'a, T, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a
         + crate::style::selection_list::Catalog
-        + iced::widget::container::Catalog
-        + iced::widget::scrollable::Catalog,
+        + iced_widget::container::Catalog
+        + iced_widget::scrollable::Catalog,
     T: Clone + Display + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
 {

--- a/src/widget/labeled_frame.rs
+++ b/src/widget/labeled_frame.rs
@@ -1,15 +1,13 @@
 //! This module provides a [`LabeledFrame`] widget which allows you to draw a border with a title around some content.
 
-use iced::advanced;
-use iced::Pixels;
-use iced::Rectangle;
+use iced_core::{Length, Pixels, Rectangle};
 
 /// The style of a [`LabeledFrame`]
 pub struct Style {
     /// The color of the border/frame
-    pub color: iced::Background,
+    pub color: iced_core::Background,
     /// The border radius of the border/frame
-    pub radius: iced::border::Radius,
+    pub radius: iced_core::border::Radius,
 }
 
 /// The theme catalog of a [`LabeledFrame`]
@@ -25,13 +23,13 @@ pub trait Catalog {
 /// A styling function for a [`LabeledFrame`]
 pub type StyleFn<'a, Theme> = Box<dyn Fn(&Theme) -> Style + 'a>;
 
-impl Catalog for iced::Theme {
+impl Catalog for iced_widget::Theme {
     type Class<'a> = StyleFn<'a, Self>;
 
     fn default<'a>() -> Self::Class<'a> {
         Box::new(|theme| Style {
-            color: iced::Background::Color(theme.extended_palette().secondary.weak.color),
-            radius: iced::border::Radius::default(),
+            color: iced_core::Background::Color(theme.extended_palette().secondary.weak.color),
+            radius: iced_core::border::Radius::default(),
         })
     }
 
@@ -45,10 +43,10 @@ pub struct LabeledFrame<'a, Message, Theme, Renderer>
 where
     Theme: Catalog,
 {
-    title: iced::Element<'a, Message, Theme, Renderer>,
-    content: iced::Element<'a, Message, Theme, Renderer>,
-    width: iced::Length,
-    height: iced::Length,
+    title: iced_core::Element<'a, Message, Theme, Renderer>,
+    content: iced_core::Element<'a, Message, Theme, Renderer>,
+    width: Length,
+    height: Length,
     class: Theme::Class<'a>,
     inset: f32,
     outset: f32,
@@ -62,14 +60,14 @@ where
 {
     /// Creates a new [`LabeledFrame`]
     pub fn new(
-        title: impl Into<iced::Element<'a, Message, Theme, Renderer>>,
-        content: impl Into<iced::Element<'a, Message, Theme, Renderer>>,
+        title: impl Into<iced_core::Element<'a, Message, Theme, Renderer>>,
+        content: impl Into<iced_core::Element<'a, Message, Theme, Renderer>>,
     ) -> Self {
         Self {
             title: title.into(),
             content: content.into(),
-            width: iced::Shrink,
-            height: iced::Shrink,
+            width: Length::Shrink,
+            height: Length::Shrink,
             class: Theme::default(),
             inset: 5.0,
             outset: 5.0,
@@ -80,14 +78,14 @@ where
 
     /// Sets the width of the [`LabeledFrame`]
     #[must_use]
-    pub fn width(mut self, width: impl Into<iced::Length>) -> Self {
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.width = width.into();
         self
     }
 
     /// Sets the height of the [`LabeledFrame`]
     #[must_use]
-    pub fn height(mut self, height: impl Into<iced::Length>) -> Self {
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
         self.height = height.into();
         self
     }
@@ -131,22 +129,22 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> advanced::Widget<Message, Theme, Renderer>
+impl<Message, Theme, Renderer> iced_core::Widget<Message, Theme, Renderer>
     for LabeledFrame<'_, Message, Theme, Renderer>
 where
-    Renderer: advanced::Renderer,
+    Renderer: iced_core::Renderer,
     Theme: Catalog,
 {
-    fn size(&self) -> iced::Size<iced::Length> {
-        iced::Size::new(self.width, self.height)
+    fn size(&self) -> iced_core::Size<Length> {
+        iced_core::Size::new(self.width, self.height)
     }
 
     fn layout(
         &mut self,
-        tree: &mut advanced::widget::Tree,
+        tree: &mut iced_core::widget::Tree,
         renderer: &Renderer,
-        limits: &advanced::layout::Limits,
-    ) -> advanced::layout::Node {
+        limits: &iced_core::layout::Limits,
+    ) -> iced_core::layout::Node {
         let limits = (*limits).height(self.height).width(self.width).loose();
         let title_layout = self
             .title
@@ -155,7 +153,7 @@ where
                 &mut tree.children[0],
                 renderer,
                 &limits.shrink(
-                    iced::Padding::default()
+                    iced_core::Padding::default()
                         .left(
                             (self.outset + self.inset + self.stroke_width) * 2.0
                                 + self.horizontal_title_padding,
@@ -178,7 +176,7 @@ where
                 &mut tree.children[1],
                 renderer,
                 &limits.shrink(
-                    iced::Padding::default()
+                    iced_core::Padding::default()
                         .left(self.outset + self.inset + self.stroke_width)
                         .right(self.outset + self.inset + self.stroke_width)
                         .bottom(self.outset + self.inset + self.stroke_width)
@@ -193,11 +191,11 @@ where
                 (self.outset + self.inset + self.stroke_width).max(title_layout.bounds().height),
             ]);
 
-        advanced::layout::Node::with_children(
+        iced_core::layout::Node::with_children(
             limits.resolve(
                 self.width,
                 self.height,
-                iced::Size::new(
+                iced_core::Size::new(
                     (content_layout.size().width
                         + (self.outset + self.inset + self.stroke_width) * 2.0)
                         .max(
@@ -213,26 +211,26 @@ where
         )
     }
 
-    fn children(&self) -> Vec<advanced::widget::Tree> {
+    fn children(&self) -> Vec<iced_core::widget::Tree> {
         vec![
-            advanced::widget::Tree::new(&self.title),
-            advanced::widget::Tree::new(&self.content),
+            iced_core::widget::Tree::new(&self.title),
+            iced_core::widget::Tree::new(&self.content),
         ]
     }
 
-    fn diff(&self, tree: &mut advanced::widget::Tree) {
+    fn diff(&self, tree: &mut iced_core::widget::Tree) {
         tree.diff_children(&[&self.title, &self.content]);
     }
 
     fn draw(
         &self,
-        tree: &advanced::widget::Tree,
+        tree: &iced_core::widget::Tree,
         renderer: &mut Renderer,
         theme: &Theme,
-        style: &advanced::renderer::Style,
-        layout: advanced::Layout<'_>,
-        cursor: advanced::mouse::Cursor,
-        viewport: &iced::Rectangle,
+        style: &iced_core::renderer::Style,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
+        viewport: &iced_core::Rectangle,
     ) {
         [&self.title, &self.content]
             .iter()
@@ -249,8 +247,8 @@ where
             title_layout.position().y + (title_layout.bounds().height - self.stroke_width) / 2.0;
         // left line
         renderer.fill_quad(
-            advanced::renderer::Quad {
-                bounds: iced::Rectangle {
+            iced_core::renderer::Quad {
+                bounds: iced_core::Rectangle {
                     x: layout.position().x + self.outset,
                     y: top_line_y,
                     width: self.stroke_width,
@@ -258,21 +256,21 @@ where
                         - self.outset
                         - (top_line_y - layout.position().y),
                 },
-                border: iced::Border {
-                    radius: iced::border::Radius::default()
+                border: iced_core::Border {
+                    radius: iced_core::border::Radius::default()
                         .top_left(style.radius.top_left)
                         .bottom_left(style.radius.bottom_left),
                     ..Default::default()
                 },
-                shadow: iced::Shadow::default(),
+                shadow: iced_core::Shadow::default(),
                 ..Default::default()
             },
             style.color,
         );
         // right line
         renderer.fill_quad(
-            advanced::renderer::Quad {
-                bounds: iced::Rectangle {
+            iced_core::renderer::Quad {
+                bounds: iced_core::Rectangle {
                     x: layout.position().x + layout.bounds().width
                         - self.outset
                         - self.stroke_width,
@@ -282,21 +280,21 @@ where
                         - self.outset
                         - (top_line_y - layout.position().y),
                 },
-                border: iced::Border {
-                    radius: iced::border::Radius::default()
+                border: iced_core::Border {
+                    radius: iced_core::border::Radius::default()
                         .top_right(style.radius.top_right)
                         .bottom_right(style.radius.bottom_right),
                     ..Default::default()
                 },
-                shadow: iced::Shadow::default(),
+                shadow: iced_core::Shadow::default(),
                 ..Default::default()
             },
             style.color,
         );
         // bottom line
         renderer.fill_quad(
-            advanced::renderer::Quad {
-                bounds: iced::Rectangle {
+            iced_core::renderer::Quad {
+                bounds: iced_core::Rectangle {
                     x: layout.position().x + self.outset,
                     y: layout.position().y + layout.bounds().height
                         - self.outset
@@ -304,21 +302,21 @@ where
                     width: layout.bounds().width - self.outset * 2.0,
                     height: self.stroke_width,
                 },
-                border: iced::Border {
-                    radius: iced::border::Radius::default()
+                border: iced_core::Border {
+                    radius: iced_core::border::Radius::default()
                         .bottom_right(style.radius.top_right)
                         .bottom_left(style.radius.top_left),
                     ..Default::default()
                 },
-                shadow: iced::Shadow::default(),
+                shadow: iced_core::Shadow::default(),
                 ..Default::default()
             },
             style.color,
         );
         // top line left
         renderer.fill_quad(
-            advanced::renderer::Quad {
-                bounds: iced::Rectangle {
+            iced_core::renderer::Quad {
+                bounds: iced_core::Rectangle {
                     x: layout.position().x + self.outset,
                     y: top_line_y,
                     width: title_layout.position().x
@@ -326,19 +324,19 @@ where
                         - self.horizontal_title_padding,
                     height: self.stroke_width,
                 },
-                border: iced::Border {
-                    radius: iced::border::Radius::default().top_left(style.radius.top_left),
+                border: iced_core::Border {
+                    radius: iced_core::border::Radius::default().top_left(style.radius.top_left),
                     ..Default::default()
                 },
-                shadow: iced::Shadow::default(),
+                shadow: iced_core::Shadow::default(),
                 ..Default::default()
             },
             style.color,
         );
         // top line right
         renderer.fill_quad(
-            advanced::renderer::Quad {
-                bounds: iced::Rectangle {
+            iced_core::renderer::Quad {
+                bounds: iced_core::Rectangle {
                     x: title_layout.position().x
                         + title_layout.bounds().width
                         + self.horizontal_title_padding,
@@ -348,11 +346,11 @@ where
                         - self.horizontal_title_padding,
                     height: self.stroke_width,
                 },
-                border: iced::Border {
-                    radius: iced::border::Radius::default().top_right(style.radius.top_right),
+                border: iced_core::Border {
+                    radius: iced_core::border::Radius::default().top_right(style.radius.top_right),
                     ..Default::default()
                 },
-                shadow: iced::Shadow::default(),
+                shadow: iced_core::Shadow::default(),
                 ..Default::default()
             },
             style.color,
@@ -361,12 +359,12 @@ where
 
     fn mouse_interaction(
         &self,
-        state: &advanced::widget::Tree,
-        layout: advanced::Layout<'_>,
-        cursor: advanced::mouse::Cursor,
-        viewport: &iced::Rectangle,
+        state: &iced_core::widget::Tree,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
+        viewport: &iced_core::Rectangle,
         renderer: &Renderer,
-    ) -> advanced::mouse::Interaction {
+    ) -> iced_core::mouse::Interaction {
         [&self.title, &self.content]
             .iter()
             .zip(&state.children)
@@ -382,14 +380,14 @@ where
 
     fn update(
         &mut self,
-        state: &mut advanced::widget::Tree,
-        event: &iced::Event,
-        layout: advanced::Layout<'_>,
-        cursor: advanced::mouse::Cursor,
+        state: &mut iced_core::widget::Tree,
+        event: &iced_core::Event,
+        layout: iced_core::Layout<'_>,
+        cursor: iced_core::mouse::Cursor,
         renderer: &Renderer,
-        clipboard: &mut dyn advanced::Clipboard,
-        shell: &mut advanced::Shell<'_, Message>,
-        viewport: &iced::Rectangle,
+        clipboard: &mut dyn iced_core::Clipboard,
+        shell: &mut iced_core::Shell<'_, Message>,
+        viewport: &iced_core::Rectangle,
     ) {
         for ((child, state), layout) in [&mut self.title, &mut self.content]
             .iter_mut()
@@ -404,10 +402,10 @@ where
 
     fn operate(
         &mut self,
-        state: &mut advanced::widget::Tree,
-        layout: advanced::Layout<'_>,
+        state: &mut iced_core::widget::Tree,
+        layout: iced_core::Layout<'_>,
         renderer: &Renderer,
-        operation: &mut dyn advanced::widget::Operation,
+        operation: &mut dyn iced_core::widget::Operation,
     ) {
         operation.container(None, layout.bounds(), &mut |operation| {
             [&mut self.title, &mut self.content]
@@ -424,12 +422,12 @@ where
 
     fn overlay<'b>(
         &'b mut self,
-        state: &'b mut advanced::widget::Tree,
-        layout: advanced::Layout<'b>,
+        state: &'b mut iced_core::widget::Tree,
+        layout: iced_core::Layout<'b>,
         renderer: &Renderer,
         viewport: &Rectangle,
-        translation: iced::Vector,
-    ) -> Option<advanced::overlay::Element<'b, Message, Theme, Renderer>> {
+        translation: iced_core::Vector,
+    ) -> Option<iced_core::overlay::Element<'b, Message, Theme, Renderer>> {
         let children = vec![&mut self.title, &mut self.content]
             .into_iter()
             .zip(&mut state.children)
@@ -441,22 +439,22 @@ where
             })
             .collect::<Vec<_>>();
 
-        (!children.is_empty()).then(|| advanced::overlay::Group::with_children(children).overlay())
+        (!children.is_empty()).then(|| iced_core::overlay::Group::with_children(children).overlay())
     }
 
-    fn size_hint(&self) -> iced::Size<iced::Length> {
+    fn size_hint(&self) -> iced_core::Size<Length> {
         self.size()
     }
 }
 
 impl<'a, Message, Theme, Renderer> From<LabeledFrame<'a, Message, Theme, Renderer>>
-    for iced::Element<'a, Message, Theme, Renderer>
+    for iced_core::Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a + Catalog,
-    Renderer: advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     fn from(value: LabeledFrame<'a, Message, Theme, Renderer>) -> Self {
-        iced::Element::new(value)
+        iced_core::Element::new(value)
     }
 }

--- a/src/widget/menu.rs
+++ b/src/widget/menu.rs
@@ -7,7 +7,7 @@
 //! ## Example 1
 //!
 //! ```ignore
-//! use iced::widget::button;
+//! use iced_widget::button;
 //! use iced_aw::menu::{Item, Menu, MenuBar};
 //!
 //! let sub_2 = Item::with_menu(
@@ -56,13 +56,13 @@
 //!
 //! ## Example 2
 //! ```
-//! use iced::widget::button;
+//! use iced_widget::button;
 //! use iced_aw::menu::{Menu, Item, MenuBar};
 //! use iced_aw::{menu_bar, menu_items};
 //!
 //! let menu_template = |items| Menu::new(items).max_width(180.0).offset(6.0);
 //!
-//! let menu_bar: MenuBar<'_, (), iced::Theme, iced::Renderer> = menu_bar!(
+//! let menu_bar: MenuBar<'_, (), iced_widget::Theme, iced::Renderer> = menu_bar!(
 //!     (button("Menu 1"),menu_template(menu_items!(
 //!         (button("item_1"))
 //!         (button("item_2"))
@@ -95,7 +95,7 @@
 //! ## Example 3
 //!
 //! ```
-//! use iced::widget::button;
+//! use iced_widget::button;
 //! use iced_aw::{menu, Menu};
 //!
 //! macro_rules! menu_template {
@@ -105,7 +105,7 @@
 //! }
 //!
 //! // then you can just write
-//! let m: Menu<'_, (), iced::Theme, iced::Renderer> = menu_template!(
+//! let m: Menu<'_, (), iced_widget::Theme, iced::Renderer> = menu_template!(
 //!     (button("item_1"))
 //!     (button("item_2"))
 //!     (button("sub menu"), menu_template!(
@@ -124,19 +124,19 @@
 //!
 //! ```
 //! use iced_aw::{menu, Menu};
-//! use iced::widget::button;
+//! use iced_widget::button;
 //!
 //! fn menu_template<'a, Message, Theme, Renderer>(
 //! menu: Menu<'a, Message, Theme, Renderer>
 //! ) -> Menu<'a, Message, Theme, Renderer>
 //! where
 //!     Theme: iced_aw::menu::Catalog,
-//!     Renderer: iced::advanced::Renderer,
+//!     Renderer: iced_core::Renderer,
 //! {
 //!     menu.max_width(180.0).offset(6.0)
 //! }
 //!
-//! let m: Menu<'_, (), iced::Theme, iced::Renderer> = menu_template(menu!(
+//! let m: Menu<'_, (), iced_widget::Theme, iced::Renderer> = menu_template(menu!(
 //!     (button("item_1"))
 //!     (button("item_2"))
 //!     (button("item_3"))

--- a/src/widget/menu/common.rs
+++ b/src/widget/menu/common.rs
@@ -1,4 +1,4 @@
-use iced::{Padding, Rectangle};
+use iced_core::{Padding, Rectangle};
 
 /* /// The condition of when to close a menu
 #[derive(Debug, Clone, Copy)]

--- a/src/widget/menu/flex.rs
+++ b/src/widget/menu/flex.rs
@@ -21,12 +21,9 @@
 #![allow(clippy::pedantic)]
 #![allow(clippy::use_self)]
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer, widget,
-    },
-    Alignment, Element, Length, Padding, Pixels, Point, Size,
+use iced_core::{
+    layout::{Limits, Node},
+    renderer, widget, Alignment, Element, Length, Padding, Pixels, Point, Size,
 };
 
 /// The main axis of a flex layout.

--- a/src/widget/menu/menu_bar.rs
+++ b/src/widget/menu/menu_bar.rs
@@ -5,14 +5,13 @@
 #![allow(clippy::wildcard_imports)]
 #![allow(clippy::enum_glob_use)]
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        mouse, overlay, renderer,
-        widget::{tree, Operation, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
-    alignment, event, Element, Event, Length, Padding, Pixels, Rectangle, Size,
+use iced_core::{
+    alignment, event,
+    layout::{Limits, Node},
+    mouse, overlay, renderer,
+    widget::{tree, Operation, Tree},
+    Clipboard, Element, Event, Layout, Length, Padding, Pixels, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 
 use super::{common::*, flex, menu_bar_overlay::MenuBarOverlay, menu_tree::*};
@@ -347,7 +346,7 @@ where
         layout: Layout<'_>,
         _renderer: &Renderer,
         _viewport: &Rectangle,
-        translation: iced::Vector,
+        translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         let state = tree.state.downcast_mut::<MenuBarState>();
 

--- a/src/widget/menu/menu_bar_overlay.rs
+++ b/src/widget/menu/menu_bar_overlay.rs
@@ -6,14 +6,11 @@
 #![allow(clippy::items_after_statements)]
 #![allow(clippy::similar_names)]
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        mouse, overlay, renderer,
-        widget::{Operation, Tree},
-        Clipboard, Layout, Shell,
-    },
-    Event, Point, Rectangle, Size, Vector,
+use iced_core::{
+    layout::{Limits, Node},
+    mouse, overlay, renderer,
+    widget::{Operation, Tree},
+    Clipboard, Event, Layout, Point, Rectangle, Shell, Size, Vector,
 };
 
 use super::{common::*, menu_bar::MenuBarState, menu_tree::*};

--- a/src/widget/menu/menu_tree.rs
+++ b/src/widget/menu/menu_tree.rs
@@ -12,17 +12,15 @@
 
 use super::common::*;
 use super::flex;
-use iced::advanced::overlay::Group;
-use iced::advanced::widget::Operation;
-use iced::Pixels;
-use iced::{
-    advanced::{
-        layout::{Layout, Limits, Node},
-        mouse, overlay, renderer,
-        widget::tree::{self, Tree},
-        Clipboard, Shell,
-    },
-    alignment, Element, Event, Length, Padding, Point, Rectangle, Size, Vector,
+use iced_core::overlay::Group;
+use iced_core::widget::Operation;
+use iced_core::Pixels;
+use iced_core::{
+    alignment,
+    layout::{Layout, Limits, Node},
+    mouse, overlay, renderer,
+    widget::tree::{self, Tree},
+    Clipboard, Element, Event, Length, Padding, Point, Rectangle, Shell, Size, Vector,
 };
 use std::iter::once;
 

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -1,27 +1,24 @@
 //! Display fields that can only be filled with numeric type.
 //!
 //! A [`NumberInput`] has some local [`State`].
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::{
-            tree::{State, Tag},
-            Operation, Tree,
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::Vertical,
     keyboard,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
+    renderer,
     widget::{
-        text_input::{self, cursor, Value},
-        Column, Container, Row, Text,
+        tree::{State, Tag},
+        Operation, Tree,
     },
-    Alignment, Background, Border, Color, Element, Event, Length, Padding, Point, Rectangle,
-    Shadow, Size,
+    Alignment, Background, Border, Clipboard, Color, Element, Event, Layout, Length, Padding,
+    Point, Rectangle, Shadow, Shell, Size, Widget,
 };
-use iced_widget::text::{LineHeight, Wrapping};
+use iced_widget::{
+    text::{LineHeight, Wrapping},
+    text_input::{self, cursor, Value},
+    Column, Container, Row, Text,
+};
 use num_traits::{bounds::Bounded, Num, NumAssignOps};
 use std::{
     fmt::Display,
@@ -62,9 +59,9 @@ const DEFAULT_PADDING: Padding = Padding::new(5.0);
 /// .step(2);
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct NumberInput<'a, T, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct NumberInput<'a, T, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
-    Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: number_input::ExtendedCatalog,
 {
     /// The current value of the [`NumberInput`].
@@ -76,9 +73,9 @@ where
     /// The max value of the [`NumberInput`].
     max: Bound<T>,
     /// The content padding of the [`NumberInput`].
-    padding: iced::Padding,
+    padding: iced_core::Padding,
     /// The text size of the [`NumberInput`].
-    size: Option<iced::Pixels>,
+    size: Option<iced_core::Pixels>,
     /// The underlying element of the [`NumberInput`].
     content: TypedInput<'a, T, InternalMessage<T>, Theme, Renderer>,
     /// The ``on_change`` event of the [`NumberInput`].
@@ -112,7 +109,7 @@ impl<'a, T, Message, Theme, Renderer> NumberInput<'a, T, Message, Theme, Rendere
 where
     T: Num + NumAssignOps + PartialOrd + Display + FromStr + Clone + Bounded + 'a,
     Message: Clone + 'a,
-    Renderer: iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: number_input::ExtendedCatalog,
 {
     /// Creates a new [`NumberInput`].
@@ -151,7 +148,7 @@ where
         }
     }
 
-    /// Sets the [`Id`](text_input::Id) of the underlying [`TextInput`](iced::widget::TextInput).
+    /// Sets the [`Id`](text_input::Id) of the underlying [`TextInput`](iced_widget::TextInput).
     #[must_use]
     pub fn id(mut self, id: impl Into<text_input::Id>) -> Self {
         self.content = self.content.id(id.into());
@@ -264,8 +261,8 @@ where
 
     /// Sets the [`Font`] of the [`Text`].
     ///
-    /// [`Font`]: iced::Font
-    /// [`Text`]: iced::widget::Text
+    /// [`Font`]: iced_core::Font
+    /// [`Text`]: iced_widget::Text
     #[allow(clippy::needless_pass_by_value)]
     #[must_use]
     pub fn font(mut self, font: Renderer::Font) -> Self {
@@ -274,9 +271,9 @@ where
         self
     }
 
-    /// Sets the [Icon](iced::widget::text_input::Icon) of the [`NumberInput`]
+    /// Sets the [Icon](iced_widget::text_input::Icon) of the [`NumberInput`]
     #[must_use]
-    pub fn icon(mut self, icon: iced::widget::text_input::Icon<Renderer::Font>) -> Self {
+    pub fn icon(mut self, icon: iced_widget::text_input::Icon<Renderer::Font>) -> Self {
         self.content = self.content.icon(icon);
         self
     }
@@ -297,7 +294,7 @@ where
 
     /// Sets the padding of the [`NumberInput`].
     #[must_use]
-    pub fn padding(mut self, padding: impl Into<iced::Padding>) -> Self {
+    pub fn padding(mut self, padding: impl Into<iced_core::Padding>) -> Self {
         let padding = padding.into();
         self.padding = padding;
         self.content = self.content.padding(padding);
@@ -306,23 +303,23 @@ where
 
     /// Sets the text size of the [`NumberInput`].
     #[must_use]
-    pub fn set_size(mut self, size: impl Into<iced::Pixels>) -> Self {
+    pub fn set_size(mut self, size: impl Into<iced_core::Pixels>) -> Self {
         let size = size.into();
         self.size = Some(size);
         self.content = self.content.size(size);
         self
     }
 
-    /// Sets the [`text::LineHeight`](iced::widget::text::LineHeight) of the [`NumberInput`].
+    /// Sets the [`text::LineHeight`](iced_widget::text::LineHeight) of the [`NumberInput`].
     #[must_use]
-    pub fn line_height(mut self, line_height: impl Into<iced::widget::text::LineHeight>) -> Self {
+    pub fn line_height(mut self, line_height: impl Into<iced_widget::text::LineHeight>) -> Self {
         self.content = self.content.line_height(line_height);
         self
     }
 
     /// Sets the horizontal alignment of the [`NumberInput`].
     #[must_use]
-    pub fn align_x(mut self, alignment: impl Into<iced::alignment::Horizontal>) -> Self {
+    pub fn align_x(mut self, alignment: impl Into<iced_core::alignment::Horizontal>) -> Self {
         self.content = self.content.align_x(alignment);
         self
     }
@@ -364,7 +361,7 @@ where
     /// ```
     /// use iced_aw::widget::number_input;
     /// // Creates a range from -5 till 5.
-    /// let input: iced_aw::NumberInput<'_, _, _, iced::Theme, iced::Renderer> = number_input(&4 /* my_value */, 0..=4, |_| () /* my_message */).bounds(-5..=5);
+    /// let input: iced_aw::NumberInput<'_, _, _, iced_widget::Theme, iced::Renderer> = number_input(&4 /* my_value */, 0..=4, |_| () /* my_message */).bounds(-5..=5);
     /// ```
     #[must_use]
     pub fn bounds(mut self, bounds: impl RangeBounds<T>) -> Self {
@@ -493,7 +490,7 @@ impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     T: Num + NumAssignOps + PartialOrd + Display + FromStr + ToString + Clone + Bounded + 'a,
     Message: 'a + Clone,
-    Renderer: 'a + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: number_input::ExtendedCatalog,
 {
     fn tag(&self) -> Tag {
@@ -739,7 +736,7 @@ where
                             keyboard::Key::Character("v") if modifiers.command() => {
                                 // We need something to paste
                                 let Some(paste) =
-                                    clipboard.read(iced::advanced::clipboard::Kind::Standard)
+                                    clipboard.read(iced_core::clipboard::Kind::Standard)
                                 else {
                                     return;
                                 };
@@ -1093,7 +1090,7 @@ where
 
         let (content, font, shaping) = down_open();
         renderer.fill_text(
-            iced::advanced::text::Text {
+            iced_core::text::Text {
                 content,
                 bounds: Size::new(dec_bounds.width, dec_bounds.height),
                 size: icon_size,
@@ -1130,7 +1127,7 @@ where
 
         let (content, font, shaping) = up_open();
         renderer.fill_text(
-            iced::advanced::text::Text {
+            iced_core::text::Text {
                 content,
                 bounds: Size::new(inc_bounds.width, inc_bounds.height),
                 size: icon_size,
@@ -1162,7 +1159,7 @@ impl<'a, T, Message, Theme, Renderer> From<NumberInput<'a, T, Message, Theme, Re
 where
     T: 'a + Num + NumAssignOps + PartialOrd + Display + FromStr + Clone + Bounded,
     Message: 'a + Clone,
-    Renderer: 'a + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + number_input::ExtendedCatalog,
 {
     fn from(num_input: NumberInput<'a, T, Message, Theme, Renderer>) -> Self {

--- a/src/widget/overlay/color_picker.rs
+++ b/src/widget/overlay/color_picker.rs
@@ -13,26 +13,23 @@ use crate::{
 };
 
 use crate::iced_aw_font::advanced_text::{cancel, ok};
-use iced::{
-    advanced::{
-        graphics::geometry::Renderer as _,
-        layout::{Limits, Node},
-        overlay, renderer,
-        text::Renderer as _,
-        widget::{self, tree::Tree},
-        Clipboard, Layout, Overlay, Renderer as _, Shell, Text, Widget,
-    },
+use iced_core::{
     alignment::{Horizontal, Vertical},
     event, keyboard,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
+    overlay, renderer,
+    text::Renderer as _,
     touch,
-    widget::{
-        canvas::{self, LineCap, Path, Stroke},
-        text::{self, Wrapping},
-        Button, Column, Row,
-    },
-    Alignment, Border, Color, Element, Event, Length, Padding, Pixels, Point, Rectangle, Renderer,
-    Size, Vector,
+    widget::{self, tree::Tree},
+    Alignment, Border, Clipboard, Color, Element, Event, Layout, Length, Overlay, Padding, Pixels,
+    Point, Rectangle, Renderer as _, Shell, Size, Text, Vector, Widget,
+};
+use iced_widget::{
+    canvas::{self, LineCap, Path, Stroke},
+    graphics::geometry::Renderer as _,
+    text::{self, Wrapping},
+    Button, Column, Renderer, Row,
 };
 use std::collections::HashMap;
 
@@ -55,7 +52,7 @@ const RGBA_STEP: i16 = 1;
 pub struct ColorPickerOverlay<'a, 'b, Message, Theme>
 where
     Message: Clone,
-    Theme: style::color_picker::Catalog + iced::widget::button::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog,
     'b: 'a,
 {
     /// The state of the [`ColorPickerOverlay`].
@@ -80,8 +77,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
     'b: 'a,
 {
     /// Creates a new [`ColorPickerOverlay`] on the given position.
@@ -102,7 +99,7 @@ where
         ColorPickerOverlay {
             state: overlay_state,
             cancel_button: Button::new(
-                iced::widget::Text::new(cancel_content)
+                iced_widget::Text::new(cancel_content)
                     .align_x(Horizontal::Center)
                     .width(Length::Fill)
                     .font(cancel_font),
@@ -110,7 +107,7 @@ where
             .width(Length::Fill)
             .on_press(on_cancel.clone()),
             submit_button: Button::new(
-                iced::widget::Text::new(submit_content)
+                iced_widget::Text::new(submit_content)
                     .align_x(Horizontal::Center)
                     .width(Length::Fill)
                     .font(submit_font),
@@ -552,8 +549,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> Node {
         let (max_width, max_height) = if bounds.width > bounds.height {
@@ -897,8 +894,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     let block1_limits = Limits::new(Size::ZERO, bounds.size())
         .width(Length::Fill)
@@ -931,8 +928,8 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     let block2_limits = Limits::new(Size::ZERO, bounds.size())
         .width(Length::Fill)
@@ -1072,8 +1069,7 @@ fn block1<Message, Theme>(
     style_sheet: &HashMap<StyleState, Style>,
 ) where
     Message: Clone,
-    Theme:
-        style::color_picker::Catalog + iced::widget::button::Catalog + iced::widget::text::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog + iced_widget::text::Catalog,
 {
     // ----------- Block 1 ----------------------
     let hsv_color_layout = layout;
@@ -1103,8 +1099,7 @@ fn block2<Message, Theme>(
     style_sheet: &HashMap<StyleState, Style>,
 ) where
     Message: Clone,
-    Theme:
-        style::color_picker::Catalog + iced::widget::button::Catalog + iced::widget::text::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog + iced_widget::text::Catalog,
 {
     // ----------- Block 2 ----------------------
     let mut block2_children = layout.children();
@@ -1215,8 +1210,7 @@ fn hsv_color<Message, Theme>(
     style_sheet: &HashMap<StyleState, Style>,
 ) where
     Message: Clone,
-    Theme:
-        style::color_picker::Catalog + iced::widget::button::Catalog + iced::widget::text::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog + iced_widget::text::Catalog,
 {
     let mut hsv_color_children = layout.children();
     let hsv_color: Hsv = color_picker.state.color.into();
@@ -1513,8 +1507,8 @@ fn rgba_color(
                 font: renderer.default_font(),
                 align_x: text::Alignment::Center,
                 align_y: Vertical::Center,
-                line_height: iced::widget::text::LineHeight::Relative(1.3),
-                shaping: iced::widget::text::Shaping::Advanced,
+                line_height: iced_widget::text::LineHeight::Relative(1.3),
+                shaping: iced_widget::text::Shaping::Advanced,
                 wrapping: Wrapping::default(),
             },
             Point::new(
@@ -1740,7 +1734,7 @@ impl Default for State {
 pub struct ColorPickerOverlayButtons<'a, Message, Theme>
 where
     Message: Clone,
-    Theme: style::color_picker::Catalog + iced::widget::button::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog,
 {
     /// The cancel button of the [`ColorPickerOverlay`].
     cancel_button: Element<'a, Message, Theme, Renderer>,
@@ -1753,8 +1747,8 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     fn default() -> Self {
         let (cancel_content, cancel_font, _cancel_shaping) = cancel();
@@ -1772,8 +1766,7 @@ impl<Message, Theme> Widget<Message, Theme, Renderer>
     for ColorPickerOverlayButtons<'_, Message, Theme>
 where
     Message: Clone,
-    Theme:
-        style::color_picker::Catalog + iced::widget::button::Catalog + iced::widget::text::Catalog,
+    Theme: style::color_picker::Catalog + iced_widget::button::Catalog + iced_widget::text::Catalog,
 {
     fn children(&self) -> Vec<Tree> {
         vec![
@@ -1814,8 +1807,8 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + style::color_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog,
 {
     fn from(overlay: ColorPickerOverlayButtons<'a, Message, Theme>) -> Self {
         Self::new(overlay)

--- a/src/widget/overlay/context_menu.rs
+++ b/src/widget/overlay/context_menu.rs
@@ -7,22 +7,24 @@ pub use crate::style::{
     status::{self, StyleFn},
 };
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::Tree,
-        Clipboard, Layout, Shell,
-    },
+use iced_core::{
     keyboard,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch, window, Border, Color, Element, Event, Point, Size,
+    overlay, renderer, touch,
+    widget::Tree,
+    window, Border, Clipboard, Color, Element, Event, Layout, Point, Shell, Size,
 };
 
 /// The overlay of the [`ContextMenu`](crate::widget::ContextMenu).
 #[allow(missing_debug_implementations)]
-pub struct ContextMenuOverlay<'a, 'b, Message, Theme = iced::Theme, Renderer = iced::Renderer>
-where
+pub struct ContextMenuOverlay<
+    'a,
+    'b,
+    Message,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> where
     Message: 'a + Clone,
     Renderer: 'a + renderer::Renderer,
     Theme: Catalog,
@@ -153,7 +155,7 @@ where
         &mut self,
         event: &Event,
         layout: Layout<'_>,
-        cursor: iced::advanced::mouse::Cursor,
+        cursor: iced_core::mouse::Cursor,
         renderer: &Renderer,
         clipboard: &mut dyn Clipboard,
         shell: &mut Shell<'_, Message>,

--- a/src/widget/overlay/date_picker.rs
+++ b/src/widget/overlay/date_picker.rs
@@ -12,36 +12,21 @@ use crate::{
     style::{date_picker::Style, style_state::StyleState, Status},
 };
 use chrono::{Datelike, Local, NaiveDate};
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        text::Renderer as _,
-        widget::tree::Tree,
-        Clipboard, Layout, Overlay, Renderer as _, Shell, Widget,
-    },
+use iced_core::{
     alignment::{Horizontal, Vertical},
-    event,
-    keyboard,
+    event, keyboard,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
+    overlay, renderer,
+    text::Renderer as _,
     touch,
-    widget::{
-        text::{self, Wrapping},
-        Button, Column, Container, Row, Text,
-    },
-    Alignment,
-    Border,
-    Color,
-    Element,
-    Event,
-    Length,
-    Padding,
-    Pixels,
-    Point,
-    Rectangle,
-    Renderer, // the actual type
-    Shadow,
-    Size,
+    widget::tree::Tree,
+    Alignment, Border, Clipboard, Color, Element, Event, Layout, Length, Overlay, Padding, Pixels,
+    Point, Rectangle, Renderer as _, Shadow, Shell, Size, Widget,
+};
+use iced_widget::{
+    text::{self, Wrapping},
+    Button, Column, Container, Renderer, Row, Text,
 };
 use std::collections::HashMap;
 
@@ -59,7 +44,7 @@ const BUTTON_SPACING: Pixels = Pixels(5.0);
 pub struct DatePickerOverlay<'a, 'b, Message, Theme>
 where
     Message: Clone,
-    Theme: crate::style::date_picker::Catalog + iced::widget::button::Catalog,
+    Theme: crate::style::date_picker::Catalog + iced_widget::button::Catalog,
     'b: 'a,
 {
     /// The state of the [`DatePickerOverlay`].
@@ -86,9 +71,9 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
     'b: 'a,
 {
     #[allow(clippy::too_many_arguments)]
@@ -418,9 +403,9 @@ where
     Message: 'static + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
     'b: 'a,
 {
     #[allow(clippy::too_many_lines)]
@@ -981,7 +966,7 @@ impl Default for State {
 pub struct DatePickerOverlayButtons<'a, Message, Theme>
 where
     Message: Clone,
-    Theme: crate::style::date_picker::Catalog + iced::widget::button::Catalog,
+    Theme: crate::style::date_picker::Catalog + iced_widget::button::Catalog,
 {
     /// The cancel button of the [`DatePickerOverlay`].
     cancel_button: Element<'a, Message, Theme, Renderer>,
@@ -994,9 +979,9 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::text::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::text::Catalog
+        + iced_widget::container::Catalog,
 {
     fn default() -> Self {
         let (cancel_content, cancel_font, _cancel_shaping) = cancel();
@@ -1027,8 +1012,8 @@ impl<Message, Theme> Widget<Message, Theme, Renderer>
 where
     Message: Clone,
     Theme: crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::container::Catalog,
 {
     fn children(&self) -> Vec<Tree> {
         vec![
@@ -1069,8 +1054,8 @@ where
     Message: 'a + Clone,
     Theme: 'a
         + crate::style::date_picker::Catalog
-        + iced::widget::button::Catalog
-        + iced::widget::container::Catalog,
+        + iced_widget::button::Catalog
+        + iced_widget::container::Catalog,
 {
     fn from(overlay: DatePickerOverlayButtons<'a, Message, Theme>) -> Self {
         Self::new(overlay)
@@ -1217,7 +1202,7 @@ fn month_year(
 
         // Left caret
         renderer.fill_text(
-            iced::advanced::Text {
+            iced_core::Text {
                 content: left_content,
                 bounds: Size::new(left_bounds.width, left_bounds.height),
                 size: Pixels(font_size.0 + if left_arrow_hovered { 1.0 } else { 0.0 }),
@@ -1238,7 +1223,7 @@ fn month_year(
 
         // Text
         renderer.fill_text(
-            iced::advanced::Text {
+            iced_core::Text {
                 content: text.to_owned(),
                 bounds: Size::new(center_bounds.width, center_bounds.height),
                 size: font_size,
@@ -1259,7 +1244,7 @@ fn month_year(
 
         // Right caret
         renderer.fill_text(
-            iced::advanced::Text {
+            iced_core::Text {
                 content: right_content,
                 bounds: Size::new(right_bounds.width, right_bounds.height),
                 size: Pixels(font_size.0 + if right_arrow_hovered { 1.0 } else { 0.0 }),
@@ -1329,7 +1314,7 @@ fn day_labels(
         let bounds = label.bounds();
 
         renderer.fill_text(
-            iced::advanced::Text {
+            iced_core::Text {
                 content: crate::core::date::WEEKDAY_LABELS[i].clone(),
                 bounds: Size::new(bounds.width, bounds.height),
                 size: font_size,
@@ -1427,7 +1412,7 @@ fn day_table(
             }
 
             renderer.fill_text(
-                iced::advanced::Text {
+                iced_core::Text {
                     content: format!("{number:02}"), // Todo: is there some way of static format as this has a fixed size?
                     bounds: Size::new(bounds.width, bounds.height),
                     size: font_size,

--- a/src/widget/overlay/time_picker.rs
+++ b/src/widget/overlay/time_picker.rs
@@ -18,40 +18,25 @@ use crate::{
     time_picker::{self, Time},
 };
 use chrono::{Duration, Local, NaiveTime, Timelike};
-use iced::{
-    advanced::{
-        graphics::geometry::Renderer as _,
-        layout::{Limits, Node},
-        overlay, renderer,
-        text::Renderer as _,
-        widget::tree::Tree,
-        Clipboard, Layout, Overlay, Renderer as _, Shell, Text, Widget,
-    },
+use iced_core::{
     alignment::{Horizontal, Vertical},
-    event,
-    keyboard,
+    event, keyboard,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
+    overlay, renderer,
+    text::Renderer as _,
     touch,
-    widget::{
-        button,
-        canvas::{self, LineCap, Path, Stroke, Text as CanvasText},
-        container,
-        text::{self, Wrapping},
-        Button, Column, Container, Row,
-    },
-    Alignment,
-    Border,
-    Color,
-    Element,
-    Event,
-    Length,
-    Padding,
-    Pixels,
-    Point,
-    Rectangle,
-    Renderer, // the actual type
-    Size,
-    Vector,
+    widget::tree::Tree,
+    Alignment, Border, Clipboard, Color, Element, Event, Layout, Length, Overlay, Padding, Pixels,
+    Point, Rectangle, Renderer as _, Shell, Size, Text, Vector, Widget,
+};
+use iced_widget::{
+    button,
+    canvas::{self, LineCap, Path, Stroke, Text as CanvasText},
+    container,
+    graphics::geometry::Renderer as _,
+    text::{self, Wrapping},
+    Button, Column, Container, Renderer, Row,
 };
 use std::collections::HashMap;
 

--- a/src/widget/quad.rs
+++ b/src/widget/quad.rs
@@ -3,15 +3,12 @@
 //! *This API requires the following crate features to be activated: `quad`*
 
 use crate::widget::InnerBounds;
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::Tree,
-        Layout, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::Cursor,
-    Background, Border, Color, Element, Length, Rectangle, Shadow, Size,
+    renderer,
+    widget::Tree,
+    Background, Border, Color, Element, Layout, Length, Rectangle, Shadow, Size, Widget,
 };
 
 /// A dummy widget that draws a quad

--- a/src/widget/selection_list.rs
+++ b/src/widget/selection_list.rs
@@ -5,22 +5,20 @@ use crate::style::{
     Status, StyleFn,
 };
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        text::{paragraph, Paragraph, Text},
-        widget::{tree, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::Vertical,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    widget::{
-        container, scrollable,
-        text::{self, LineHeight, Wrapping},
-        Container, Scrollable,
-    },
-    Border, Element, Event, Font, Length, Padding, Pixels, Rectangle, Size,
+    renderer,
+    text::{paragraph, Paragraph, Text},
+    widget::{tree, Tree},
+    Border, Clipboard, Element, Event, Font, Layout, Length, Padding, Pixels, Rectangle, Shell,
+    Size, Widget,
+};
+use iced_widget::{
+    container, scrollable,
+    text::{self, LineHeight, Wrapping},
+    Container, Scrollable,
 };
 use std::{fmt::Display, hash::Hash, marker::PhantomData};
 
@@ -29,11 +27,16 @@ pub use list::List;
 /// A widget for selecting a single value from a dynamic scrollable list of options.
 #[allow(missing_debug_implementations)]
 #[allow(clippy::type_repetition_in_bounds)]
-pub struct SelectionList<'a, T, Message, Theme = iced::Theme, Renderer = iced::Renderer>
-where
+pub struct SelectionList<
+    'a,
+    T,
+    Message,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> where
     T: Clone + ToString + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + container::Catalog,
 {
     /// Container for Rendering List.
@@ -58,7 +61,7 @@ where
 impl<'a, T, Message, Theme, Renderer> SelectionList<'a, T, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + container::Catalog + scrollable::Catalog,
     T: Clone + Display + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
@@ -175,7 +178,7 @@ impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     T: 'a + Clone + ToString + Eq + Hash + Display,
     Message: 'static,
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font> + 'a,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font> + 'a,
     Theme: Catalog + container::Catalog,
 {
     fn children(&self) -> Vec<Tree> {
@@ -334,7 +337,7 @@ impl<'a, T, Message, Theme, Renderer> From<SelectionList<'a, T, Message, Theme, 
 where
     T: Clone + ToString + Eq + Hash + Display,
     Message: 'static,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + container::Catalog,
 {
     fn from(selection_list: SelectionList<'a, T, Message, Theme, Renderer>) -> Self {
@@ -349,7 +352,7 @@ pub struct State<P: Paragraph> {
 }
 
 impl<P: Paragraph> State<P> {
-    /// Creates a new [`State`], representing an unfocused [`TextInput`](iced::widget::TextInput).
+    /// Creates a new [`State`], representing an unfocused [`TextInput`](iced_widget::TextInput).
     pub fn new<T>(options: &[T]) -> Self
     where
         T: Clone + Display + Eq + Hash,

--- a/src/widget/selection_list/list.rs
+++ b/src/widget/selection_list/list.rs
@@ -2,21 +2,18 @@
 
 use crate::selection_list::Catalog;
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::{
-            tree::{State, Tag},
-            Tree,
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::Vertical,
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch,
+    renderer, touch,
     widget::text::{LineHeight, Wrapping},
-    Border, Color, Element, Event, Length, Padding, Pixels, Point, Rectangle, Size,
+    widget::{
+        tree::{State, Tag},
+        Tree,
+    },
+    Border, Clipboard, Color, Element, Event, Layout, Length, Padding, Pixels, Point, Rectangle,
+    Shell, Size, Widget,
 };
 use std::{
     collections::hash_map::DefaultHasher,
@@ -31,7 +28,7 @@ pub struct List<'a, T: 'a, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     /// Options pointer to hold all rendered strings
@@ -68,7 +65,7 @@ impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for List<'_, T, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
 {
     fn tag(&self) -> Tag {
@@ -266,7 +263,7 @@ where
             };
 
             renderer.fill_text(
-                iced::advanced::text::Text {
+                iced_core::text::Text {
                     content: self.options[i].to_string(),
                     bounds: Size::new(f32::INFINITY, bounds.height),
                     size: Pixels(self.text_size),
@@ -274,7 +271,7 @@ where
                     align_x: iced_widget::text::Alignment::Left,
                     align_y: Vertical::Center,
                     line_height: LineHeight::default(),
-                    shaping: iced::widget::text::Shaping::Advanced,
+                    shaping: iced_widget::text::Shaping::Advanced,
                     wrapping: Wrapping::default(),
                 },
                 Point::new(bounds.x, bounds.center_y()),
@@ -290,7 +287,7 @@ impl<'a, T, Message, Theme, Renderer> From<List<'a, T, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
     Message: 'a,
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog,
 {
     fn from(list: List<'a, T, Message, Theme, Renderer>) -> Self {

--- a/src/widget/sidebar/column.rs
+++ b/src/widget/sidebar/column.rs
@@ -6,22 +6,20 @@
 //! Future: Idea to implement leaders before/after the flushed element for `Start`/`End`
 //! alignments.
 
-use iced::{
-    advanced::{
-        layout::{self, Node},
-        mouse, overlay, renderer,
-        widget::{tree::Tree, Operation},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment,
     event::Event,
-    widget::Row,
-    Alignment, Element, Length, Padding, Pixels, Point, Rectangle, Size, Vector,
+    layout::{self, Node},
+    mouse, overlay, renderer,
+    widget::{tree::Tree, Operation},
+    Alignment, Clipboard, Element, Layout, Length, Padding, Pixels, Point, Rectangle, Shell, Size,
+    Vector, Widget,
 };
+use iced_widget::Row;
 
 /// A container that distributes its contents vertically.
 #[allow(missing_debug_implementations)]
-pub struct FlushColumn<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer> {
+pub struct FlushColumn<'a, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer> {
     spacing: Pixels,
     padding: Padding,
     width: Length,
@@ -35,7 +33,7 @@ pub struct FlushColumn<'a, Message, Theme = iced::Theme, Renderer = iced::Render
 
 impl<'a, Message: 'a, Theme: 'a, Renderer> FlushColumn<'a, Message, Theme, Renderer>
 where
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     /// Creates an empty [`FlushColumn`].
     #[must_use]
@@ -181,14 +179,14 @@ where
 #[allow(clippy::mismatching_type_param_order)]
 impl<'a, Message: 'a, Renderer> Default for FlushColumn<'a, Message, Renderer>
 where
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a, Message: 'a, Theme: 'a, Renderer: iced::advanced::Renderer + 'a>
+impl<'a, Message: 'a, Theme: 'a, Renderer: iced_core::Renderer + 'a>
     FromIterator<Row<'a, Message, Theme, Renderer>> for FlushColumn<'a, Message, Theme, Renderer>
 {
     fn from_iter<T: IntoIterator<Item = Row<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
@@ -199,7 +197,7 @@ impl<'a, Message: 'a, Theme: 'a, Renderer: iced::advanced::Renderer + 'a>
 impl<'a, Message: 'a, Theme: 'a, Renderer> Widget<Message, Theme, Renderer>
     for FlushColumn<'a, Message, Theme, Renderer>
 where
-    Renderer: iced::advanced::Renderer,
+    Renderer: iced_core::Renderer,
 {
     fn children(&self) -> Vec<Tree> {
         self.children.iter().map(Tree::new).collect()
@@ -422,7 +420,7 @@ impl<'a, Message, Theme, Renderer> From<FlushColumn<'a, Message, Theme, Renderer
 where
     Message: 'a,
     Theme: 'a,
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     fn from(column: FlushColumn<'a, Message, Theme, Renderer>) -> Self {
         Self::new(column)

--- a/src/widget/sidebar/row.rs
+++ b/src/widget/sidebar/row.rs
@@ -6,22 +6,20 @@
 //! Future: Idea to implement leaders before/after the flushed element for `Start`/`End`
 //! alignments.
 
-use iced::{
-    advanced::{
-        layout::{self, Node},
-        mouse, overlay, renderer,
-        widget::{tree::Tree, Operation},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment,
     event::Event,
-    widget::Column,
-    Alignment, Element, Length, Padding, Pixels, Point, Rectangle, Size, Vector,
+    layout::{self, Node},
+    mouse, overlay, renderer,
+    widget::{tree::Tree, Operation},
+    Alignment, Clipboard, Element, Layout, Length, Padding, Pixels, Point, Rectangle, Shell, Size,
+    Vector, Widget,
 };
+use iced_widget::Column;
 
 /// A container that distributes its contents horizontally.
 #[allow(missing_debug_implementations)]
-pub struct FlushRow<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer> {
+pub struct FlushRow<'a, Message, Theme = iced_core::Theme, Renderer = iced_widget::Renderer> {
     spacing: Pixels,
     padding: Padding,
     width: Length,
@@ -35,7 +33,7 @@ pub struct FlushRow<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
 
 impl<'a, Message: 'a, Theme: 'a, Renderer> FlushRow<'a, Message, Theme, Renderer>
 where
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     /// Creates an empty [`FlushRow`].
     #[must_use]
@@ -184,14 +182,14 @@ where
 #[allow(clippy::mismatching_type_param_order)]
 impl<'a, Message: 'a, Renderer> Default for FlushRow<'a, Message, Renderer>
 where
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a, Message: 'a, Theme: 'a, Renderer: iced::advanced::Renderer + 'a>
+impl<'a, Message: 'a, Theme: 'a, Renderer: iced_core::Renderer + 'a>
     FromIterator<Column<'a, Message, Theme, Renderer>> for FlushRow<'a, Message, Theme, Renderer>
 {
     fn from_iter<T: IntoIterator<Item = Column<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
@@ -202,7 +200,7 @@ impl<'a, Message: 'a, Theme: 'a, Renderer: iced::advanced::Renderer + 'a>
 impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
     for FlushRow<'_, Message, Theme, Renderer>
 where
-    Renderer: iced::advanced::Renderer,
+    Renderer: iced_core::Renderer,
 {
     fn children(&self) -> Vec<Tree> {
         self.children.iter().map(Tree::new).collect()
@@ -427,7 +425,7 @@ impl<'a, Message, Theme, Renderer> From<FlushRow<'a, Message, Theme, Renderer>>
 where
     Message: 'a,
     Theme: 'a,
-    Renderer: iced::advanced::Renderer + 'a,
+    Renderer: iced_core::Renderer + 'a,
 {
     fn from(row: FlushRow<'a, Message, Theme, Renderer>) -> Self {
         Self::new(row)

--- a/src/widget/sidebar/sidebar.rs
+++ b/src/widget/sidebar/sidebar.rs
@@ -16,25 +16,21 @@ use crate::{
     },
     ICED_AW_FONT,
 };
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::{
-            tree::{State, Tag},
-            Operation, Tree,
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::{self, Vertical},
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch,
+    overlay, renderer, touch,
     widget::{
-        text::{self, LineHeight, Wrapping},
-        Row, Text,
+        tree::{State, Tag},
+        Operation, Tree,
     },
-    Alignment, Background, Border, Color, Element, Event, Font, Length, Padding, Pixels, Point,
-    Rectangle, Shadow, Size, Vector,
+    Alignment, Background, Border, Clipboard, Color, Element, Event, Font, Layout, Length, Padding,
+    Pixels, Point, Rectangle, Shadow, Shell, Size, Vector, Widget,
+};
+use iced_widget::{
+    text::{self, LineHeight, Wrapping},
+    Row, Text,
 };
 use std::marker::PhantomData;
 
@@ -108,9 +104,9 @@ pub enum Position {
 /// .set_active_tab(&TabId::One);
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct Sidebar<'a, Message, TabId, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct Sidebar<'a, Message, TabId, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer,
+    Renderer: renderer::Renderer + iced_core::text::Renderer,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -158,7 +154,7 @@ where
 
 impl<'a, Message, TabId, Theme, Renderer> Sidebar<'a, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -389,7 +385,7 @@ where
 impl<Message, TabId, Theme, Renderer> Widget<Message, Theme, Renderer>
     for Sidebar<'_, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -404,16 +400,16 @@ where
             font: Option<Font>,
         ) -> Text<'_, Theme, Renderer>
         where
-            Renderer: iced::advanced::text::Renderer,
+            Renderer: iced_core::text::Renderer,
             Renderer::Font: From<Font>,
-            Theme: iced::widget::text::Catalog,
+            Theme: iced_widget::text::Catalog,
         {
             Text::<Theme, Renderer>::new(icon.to_string())
                 .size(size)
                 .font(font.unwrap_or_default())
                 .align_x(alignment::Horizontal::Center)
                 .align_y(alignment::Vertical::Center)
-                .shaping(iced::advanced::text::Shaping::Advanced)
+                .shaping(iced_core::text::Shaping::Advanced)
                 .width(Length::Shrink)
         }
 
@@ -423,9 +419,9 @@ where
             font: Option<Font>,
         ) -> Text<'_, Theme, Renderer>
         where
-            Renderer: iced::advanced::text::Renderer,
+            Renderer: iced_core::text::Renderer,
             Renderer::Font: From<Font>,
-            Theme: iced::widget::text::Catalog,
+            Theme: iced_widget::text::Catalog,
         {
             Text::<Theme, Renderer>::new(text)
                 .size(size)
@@ -673,7 +669,7 @@ fn draw_tab<Theme, Renderer>(
     on_close: bool,
     close_position: &Position,
 ) where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + text::Catalog,
 {
     fn icon_bound_rectangle(item: Option<Layout<'_>>) -> Rectangle {
@@ -695,14 +691,14 @@ fn draw_tab<Theme, Renderer>(
         style: &Style,
         position: Position,
     ) where
-        Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+        Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     {
         let mut label_layout_children = label_layout.children();
         match tab {
             TabLabel::Icon(icon) => {
                 let icon_bounds = icon_bound_rectangle(label_layout_children.next());
                 renderer.fill_text(
-                    iced::advanced::text::Text {
+                    iced_core::text::Text {
                         content: icon.to_string(),
                         bounds: Size::new(icon_bounds.width, icon_bounds.height),
                         size: Pixels(icon_data.1),
@@ -710,7 +706,7 @@ fn draw_tab<Theme, Renderer>(
                         align_x: text::Alignment::Center,
                         align_y: Vertical::Center,
                         line_height: LineHeight::Relative(1.3),
-                        shaping: iced::advanced::text::Shaping::Advanced,
+                        shaping: iced_core::text::Shaping::Advanced,
                         wrapping: Wrapping::default(),
                     },
                     Point::new(icon_bounds.center_x(), icon_bounds.center_y()),
@@ -721,7 +717,7 @@ fn draw_tab<Theme, Renderer>(
             TabLabel::Text(text) => {
                 let text_bounds = text_bound_rectangle(label_layout_children.next());
                 renderer.fill_text(
-                    iced::advanced::text::Text {
+                    iced_core::text::Text {
                         content: text.clone(),
                         bounds: Size::new(text_bounds.width, text_bounds.height),
                         size: Pixels(text_data.1),
@@ -729,7 +725,7 @@ fn draw_tab<Theme, Renderer>(
                         align_x: text::Alignment::Center,
                         align_y: Vertical::Center,
                         line_height: LineHeight::Relative(1.3),
-                        shaping: iced::advanced::text::Shaping::Advanced,
+                        shaping: iced_core::text::Shaping::Advanced,
                         wrapping: Wrapping::default(),
                     },
                     Point::new(text_bounds.center_x(), text_bounds.center_y()),
@@ -751,7 +747,7 @@ fn draw_tab<Theme, Renderer>(
                     }
                 }
                 renderer.fill_text(
-                    iced::advanced::text::Text {
+                    iced_core::text::Text {
                         content: icon.to_string(),
                         bounds: Size::new(icon_bounds.width, icon_bounds.height),
                         size: Pixels(icon_data.1),
@@ -759,7 +755,7 @@ fn draw_tab<Theme, Renderer>(
                         align_x: text::Alignment::Center,
                         align_y: Vertical::Center,
                         line_height: LineHeight::Relative(1.3),
-                        shaping: iced::advanced::text::Shaping::Advanced,
+                        shaping: iced_core::text::Shaping::Advanced,
                         wrapping: Wrapping::default(),
                     },
                     Point::new(icon_bounds.center_x(), icon_bounds.center_y()),
@@ -767,7 +763,7 @@ fn draw_tab<Theme, Renderer>(
                     icon_bounds,
                 );
                 renderer.fill_text(
-                    iced::advanced::text::Text {
+                    iced_core::text::Text {
                         content: text.clone(),
                         bounds: Size::new(text_bounds.width, text_bounds.height),
                         size: Pixels(text_data.1),
@@ -775,7 +771,7 @@ fn draw_tab<Theme, Renderer>(
                         align_x: text::Alignment::Center,
                         align_y: Vertical::Center,
                         line_height: LineHeight::Relative(1.3),
-                        shaping: iced::advanced::text::Shaping::Advanced,
+                        shaping: iced_core::text::Shaping::Advanced,
                         wrapping: Wrapping::default(),
                     },
                     Point::new(text_bounds.center_x(), text_bounds.center_y()),
@@ -794,13 +790,13 @@ fn draw_tab<Theme, Renderer>(
         close_size: f32,
         viewport: &Rectangle,
     ) where
-        Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+        Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     {
         let cross_bounds = cross_layout.bounds();
         let is_mouse_over_cross = cursor.is_over(cross_bounds);
         let (content, font, shaping) = iced_aw_font::advanced_text::cancel();
         renderer.fill_text(
-            iced::advanced::text::Text {
+            iced_core::text::Text {
                 content,
                 bounds: Size::new(cross_bounds.width, cross_bounds.height),
                 size: Pixels(close_size + if is_mouse_over_cross { 1.0 } else { 0.0 }),
@@ -917,7 +913,7 @@ fn draw_tab<Theme, Renderer>(
 impl<'a, Message, TabId, Theme, Renderer> From<Sidebar<'a, Message, TabId, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + text::Catalog,
     Message: 'a,
     TabId: 'a + Eq + Clone,
@@ -950,7 +946,7 @@ pub enum SidebarPosition {
 /// # Example
 /// ```ignore
 /// # use iced_aw::{TabLabel, tabs::SidebarWithContent};
-/// # use iced::widget::Text;
+/// # use iced_widget::Text;
 /// #
 /// #[derive(Debug, Clone)]
 /// enum Message {
@@ -972,9 +968,14 @@ pub enum SidebarPosition {
 /// ```
 ///
 #[allow(missing_debug_implementations)]
-pub struct SidebarWithContent<'a, Message, TabId, Theme = iced::Theme, Renderer = iced::Renderer>
-where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer,
+pub struct SidebarWithContent<
+    'a,
+    Message,
+    TabId,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> where
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -994,7 +995,7 @@ where
 
 impl<'a, Message, TabId, Theme, Renderer> SidebarWithContent<'a, Message, TabId, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -1210,7 +1211,7 @@ where
 impl<Message, TabId, Theme, Renderer> Widget<Message, Theme, Renderer>
     for SidebarWithContent<'_, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -1514,7 +1515,7 @@ impl<'a, Message, TabId, Theme, Renderer>
     From<SidebarWithContent<'a, Message, TabId, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: 'a + Catalog + text::Catalog,
     Message: 'a,
     TabId: 'a + Eq + Clone,

--- a/src/widget/slide_bar.rs
+++ b/src/widget/slide_bar.rs
@@ -2,15 +2,13 @@
 //!
 //! *This API requires the following crate features to be activated: `quad`*
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::tree::{self, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch, Border, Color, Element, Event, Length, Point, Rectangle, Shadow, Size,
+    renderer, touch,
+    widget::tree::{self, Tree},
+    Border, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Shadow, Shell,
+    Size, Widget,
 };
 
 use std::ops::RangeInclusive;

--- a/src/widget/spinner.rs
+++ b/src/widget/spinner.rs
@@ -1,17 +1,15 @@
 //! A spinner to suggest something is loading.
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::{
-            tree::{State, Tag},
-            Tree,
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::Cursor,
+    renderer,
     time::{Duration, Instant},
-    window, Border, Color, Element, Event, Length, Rectangle, Size, Vector,
+    widget::{
+        tree::{State, Tag},
+        Tree,
+    },
+    window, Border, Clipboard, Color, Element, Event, Layout, Length, Rectangle, Shell, Size,
+    Vector, Widget,
 };
 
 /// A spinner widget, a circle spinning around the center of the widget.

--- a/src/widget/tab_bar.rs
+++ b/src/widget/tab_bar.rs
@@ -7,22 +7,18 @@
 
 pub mod tab_label;
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        renderer,
-        widget::Tree,
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
     alignment::{self, Vertical},
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    touch,
-    widget::{
-        text::{self, LineHeight, Wrapping},
-        Column, Row, Text,
-    },
-    window, Alignment, Background, Border, Color, Element, Event, Font, Length, Padding, Pixels,
-    Point, Rectangle, Shadow, Size,
+    renderer, touch,
+    widget::Tree,
+    window, Alignment, Background, Border, Clipboard, Color, Element, Event, Font, Layout, Length,
+    Padding, Pixels, Point, Rectangle, Shadow, Shell, Size, Widget,
+};
+use iced_widget::{
+    text::{self, LineHeight, Wrapping},
+    Column, Row, Text,
 };
 
 use std::marker::PhantomData;
@@ -72,9 +68,9 @@ const DEFAULT_SPACING: Pixels = Pixels::ZERO;
 /// .set_active_tab(&TabId::One);
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct TabBar<'a, Message, TabId, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct TabBar<'a, Message, TabId, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer,
+    Renderer: renderer::Renderer + iced_core::text::Renderer,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -136,7 +132,7 @@ pub enum Position {
 
 impl<'a, Message, TabId, Theme, Renderer> TabBar<'a, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -360,7 +356,7 @@ where
 impl<Message, TabId, Theme, Renderer> Widget<Message, Theme, Renderer>
     for TabBar<'_, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -375,16 +371,16 @@ where
             font: Option<Font>,
         ) -> Text<'_, Theme, Renderer>
         where
-            Renderer: iced::advanced::text::Renderer,
+            Renderer: iced_core::text::Renderer,
             Renderer::Font: From<Font>,
-            Theme: iced::widget::text::Catalog,
+            Theme: iced_widget::text::Catalog,
         {
             Text::<Theme, Renderer>::new(icon.to_string())
                 .size(size)
                 .font(font.unwrap_or_default())
                 .align_x(alignment::Horizontal::Center)
                 .align_y(alignment::Vertical::Center)
-                .shaping(iced::advanced::text::Shaping::Advanced)
+                .shaping(iced_core::text::Shaping::Advanced)
                 .width(Length::Shrink)
         }
 
@@ -394,9 +390,9 @@ where
             font: Option<Font>,
         ) -> Text<'_, Theme, Renderer>
         where
-            Renderer: iced::advanced::text::Renderer,
+            Renderer: iced_core::text::Renderer,
             Renderer::Font: From<Font>,
-            Theme: iced::widget::text::Catalog,
+            Theme: iced_widget::text::Catalog,
         {
             Text::<Theme, Renderer>::new(text)
                 .size(size)
@@ -718,7 +714,7 @@ fn draw_tab<Theme, Renderer>(
     close_size: f32,
     viewport: &Rectangle,
 ) where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + text::Catalog,
 {
     fn icon_bound_rectangle(item: Option<Layout<'_>>) -> Rectangle {
@@ -762,7 +758,7 @@ fn draw_tab<Theme, Renderer>(
             let icon_bounds = icon_bound_rectangle(label_layout_children.next());
 
             renderer.fill_text(
-                iced::advanced::text::Text {
+                iced_core::text::Text {
                     content: icon.to_string(),
                     bounds: Size::new(icon_bounds.width, icon_bounds.height),
                     size: Pixels(icon_data.1),
@@ -770,7 +766,7 @@ fn draw_tab<Theme, Renderer>(
                     align_x: text::Alignment::Center,
                     align_y: Vertical::Center,
                     line_height: LineHeight::Relative(1.3),
-                    shaping: iced::advanced::text::Shaping::Advanced,
+                    shaping: iced_core::text::Shaping::Advanced,
                     wrapping: Wrapping::default(),
                 },
                 Point::new(icon_bounds.center_x(), icon_bounds.center_y()),
@@ -783,7 +779,7 @@ fn draw_tab<Theme, Renderer>(
             let text_bounds = text_bound_rectangle(label_layout_children.next());
 
             renderer.fill_text(
-                iced::advanced::text::Text {
+                iced_core::text::Text {
                     content: text.clone(),
                     bounds: Size::new(text_bounds.width, text_bounds.height),
                     size: Pixels(text_data.1),
@@ -791,7 +787,7 @@ fn draw_tab<Theme, Renderer>(
                     align_x: text::Alignment::Center,
                     align_y: Vertical::Center,
                     line_height: LineHeight::Relative(1.3),
-                    shaping: iced::advanced::text::Shaping::Advanced,
+                    shaping: iced_core::text::Shaping::Advanced,
                     wrapping: Wrapping::default(),
                 },
                 Point::new(text_bounds.center_x(), text_bounds.center_y()),
@@ -831,7 +827,7 @@ fn draw_tab<Theme, Renderer>(
             }
 
             renderer.fill_text(
-                iced::advanced::text::Text {
+                iced_core::text::Text {
                     content: icon.to_string(),
                     bounds: Size::new(icon_bounds.width, icon_bounds.height),
                     size: Pixels(icon_data.1),
@@ -839,7 +835,7 @@ fn draw_tab<Theme, Renderer>(
                     align_x: text::Alignment::Center,
                     align_y: Vertical::Center,
                     line_height: LineHeight::Relative(1.3),
-                    shaping: iced::advanced::text::Shaping::Advanced,
+                    shaping: iced_core::text::Shaping::Advanced,
                     wrapping: Wrapping::default(),
                 },
                 Point::new(icon_bounds.center_x(), icon_bounds.center_y()),
@@ -848,7 +844,7 @@ fn draw_tab<Theme, Renderer>(
             );
 
             renderer.fill_text(
-                iced::advanced::text::Text {
+                iced_core::text::Text {
                     content: text.clone(),
                     bounds: Size::new(text_bounds.width, text_bounds.height),
                     size: Pixels(text_data.1),
@@ -856,7 +852,7 @@ fn draw_tab<Theme, Renderer>(
                     align_x: text::Alignment::Center,
                     align_y: Vertical::Center,
                     line_height: LineHeight::Relative(1.3),
-                    shaping: iced::advanced::text::Shaping::Advanced,
+                    shaping: iced_core::text::Shaping::Advanced,
                     wrapping: Wrapping::default(),
                 },
                 Point::new(text_bounds.center_x(), text_bounds.center_y()),
@@ -873,7 +869,7 @@ fn draw_tab<Theme, Renderer>(
         let (content, font, shaping) = cancel();
 
         renderer.fill_text(
-            iced::advanced::text::Text {
+            iced_core::text::Text {
                 content,
                 bounds: Size::new(cross_bounds.width, cross_bounds.height),
                 size: Pixels(close_size + if is_mouse_over_cross { 1.0 } else { 0.0 }),
@@ -912,7 +908,7 @@ fn draw_tab<Theme, Renderer>(
 impl<'a, Message, TabId, Theme, Renderer> From<TabBar<'a, Message, TabId, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = iced::Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + text::Catalog,
     Message: 'a,
     TabId: 'a + Eq + Clone,

--- a/src/widget/tabs.rs
+++ b/src/widget/tabs.rs
@@ -17,20 +17,18 @@ use crate::{
     TabLabel,
 };
 
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::{
-            tree::{State, Tag},
-            Operation, Tree,
-        },
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    widget::{text, Row},
-    Element, Event, Font, Length, Padding, Pixels, Point, Rectangle, Size, Vector,
+    overlay, renderer,
+    widget::{
+        tree::{State, Tag},
+        Operation, Tree,
+    },
+    Clipboard, Element, Event, Font, Layout, Length, Padding, Pixels, Point, Rectangle, Shell,
+    Size, Vector, Widget,
 };
+use iced_widget::{text, Row};
 
 pub use tab_bar_position::TabBarPosition;
 
@@ -40,7 +38,7 @@ pub use tab_bar_position::TabBarPosition;
 /// # Example
 /// ```ignore
 /// # use iced_aw::{TabLabel, tabs::Tabs};
-/// # use iced::widget::Text;
+/// # use iced_widget::Text;
 /// #
 /// #[derive(Debug, Clone)]
 /// enum Message {
@@ -62,9 +60,9 @@ pub use tab_bar_position::TabBarPosition;
 /// ```
 ///
 #[allow(missing_debug_implementations)]
-pub struct Tabs<'a, Message, TabId, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct Tabs<'a, Message, TabId, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer,
     Theme: Catalog,
     TabId: Eq + Clone,
 {
@@ -86,7 +84,7 @@ where
 
 impl<'a, Message, TabId, Theme, Renderer> Tabs<'a, Message, TabId, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -303,7 +301,7 @@ where
 impl<Message, TabId, Theme, Renderer> Widget<Message, Theme, Renderer>
     for Tabs<'_, Message, TabId, Theme, Renderer>
 where
-    Renderer: renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: Catalog + text::Catalog,
     TabId: Eq + Clone,
 {
@@ -622,7 +620,7 @@ where
 impl<'a, Message, TabId, Theme, Renderer> From<Tabs<'a, Message, TabId, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    Renderer: 'a + renderer::Renderer + iced::advanced::text::Renderer<Font = Font>,
+    Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = Font>,
     Theme: 'a + Catalog + text::Catalog,
     Message: 'a,
     TabId: 'a + Eq + Clone,

--- a/src/widget/time_picker.rs
+++ b/src/widget/time_picker.rs
@@ -5,24 +5,14 @@
 use super::overlay::time_picker::{self, TimePickerOverlay, TimePickerOverlayButtons};
 
 use chrono::Local;
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::tree::{self, Tag, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    widget::{button, container, text},
-    Element,
-    Event,
-    Length,
-    Point,
-    Rectangle,
-    Renderer, // the actual type
-    Size,
-    Vector,
+    overlay, renderer,
+    widget::tree::{self, Tag, Tree},
+    Clipboard, Element, Event, Layout, Length, Point, Rectangle, Shell, Size, Vector, Widget,
 };
+use iced_widget::{button, container, text, Renderer};
 
 pub use crate::{
     core::time::{Period, Time},

--- a/src/widget/typed_input.rs
+++ b/src/widget/typed_input.rs
@@ -2,18 +2,16 @@
 //!
 //! *This API requires the following crate features to be activated: `typed_input`*
 
-use iced::advanced::layout::{Layout, Limits, Node};
-use iced::advanced::widget::{
+use iced_core::layout::{Layout, Limits, Node};
+use iced_core::mouse::{self, Cursor};
+use iced_core::widget::{
     tree::{State, Tag},
     Operation, Tree, Widget,
 };
-use iced::advanced::{Clipboard, Shell};
-use iced::mouse::{self, Cursor};
-use iced::{
-    widget::text_input::{self, TextInput},
-    Event, Size,
-};
-use iced::{Element, Length, Padding, Pixels, Rectangle};
+use iced_core::{Clipboard, Shell};
+use iced_core::{Element, Length, Padding, Pixels, Rectangle};
+use iced_core::{Event, Size};
+use iced_widget::text_input::{self, TextInput};
 
 use std::{fmt::Display, str::FromStr};
 
@@ -38,9 +36,9 @@ const DEFAULT_PADDING: Padding = Padding::new(5.0);
 ///     Message::TypedInputChanged,
 /// );
 /// ```
-pub struct TypedInput<'a, T, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+pub struct TypedInput<'a, T, Message, Theme = iced_widget::Theme, Renderer = iced_widget::Renderer>
 where
-    Renderer: iced::advanced::text::Renderer,
+    Renderer: iced_core::text::Renderer,
     Theme: text_input::Catalog,
 {
     /// The current value of the [`TypedInput`].
@@ -69,7 +67,7 @@ impl<'a, T, Message, Theme, Renderer> TypedInput<'a, T, Message, Theme, Renderer
 where
     T: Display + FromStr,
     Message: Clone,
-    Renderer: iced::advanced::text::Renderer,
+    Renderer: iced_core::text::Renderer,
     Theme: text_input::Catalog,
 {
     /// Creates a new [`TypedInput`].
@@ -229,16 +227,16 @@ where
         self
     }
 
-    /// Sets the [Font](iced::advanced::text::Renderer::Font) of the [`TypedInput`].
+    /// Sets the [Font](iced_core::text::Renderer::Font) of the [`TypedInput`].
     #[must_use]
     pub fn font(mut self, font: Renderer::Font) -> Self {
         self.text_input = self.text_input.font(font);
         self
     }
 
-    /// Sets the [Icon](iced::widget::text_input::Icon) of the [`TypedInput`]
+    /// Sets the [Icon](iced_widget::text_input::Icon) of the [`TypedInput`]
     #[must_use]
-    pub fn icon(mut self, icon: iced::widget::text_input::Icon<Renderer::Font>) -> Self {
+    pub fn icon(mut self, icon: iced_widget::text_input::Icon<Renderer::Font>) -> Self {
         self.text_input = self.text_input.icon(icon);
         self
     }
@@ -264,16 +262,16 @@ where
         self
     }
 
-    /// Sets the [`text::LineHeight`](iced::widget::text::LineHeight) of the [`TypedInput`].
+    /// Sets the [`text::LineHeight`](iced_widget::text::LineHeight) of the [`TypedInput`].
     #[must_use]
-    pub fn line_height(mut self, line_height: impl Into<iced::widget::text::LineHeight>) -> Self {
+    pub fn line_height(mut self, line_height: impl Into<iced_widget::text::LineHeight>) -> Self {
         self.text_input = self.text_input.line_height(line_height);
         self
     }
 
     /// Sets the horizontal alignment of the [`TypedInput`].
     #[must_use]
-    pub fn align_x(mut self, alignment: impl Into<iced::alignment::Horizontal>) -> Self {
+    pub fn align_x(mut self, alignment: impl Into<iced_core::alignment::Horizontal>) -> Self {
         self.text_input = self.text_input.align_x(alignment);
         self
     }
@@ -309,7 +307,7 @@ impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
 where
     T: Display + FromStr + Clone + PartialEq,
     Message: 'a + Clone,
-    Renderer: 'a + iced::advanced::text::Renderer,
+    Renderer: 'a + iced_core::text::Renderer,
     Theme: text_input::Catalog,
 {
     fn tag(&self) -> Tag {
@@ -345,7 +343,7 @@ where
         state: &Tree,
         renderer: &mut Renderer,
         theme: &Theme,
-        style: &iced::advanced::renderer::Style,
+        style: &iced_core::renderer::Style,
         layout: Layout<'_>,
         cursor: Cursor,
         viewport: &Rectangle,
@@ -481,7 +479,7 @@ impl<'a, T, Message, Theme, Renderer> From<TypedInput<'a, T, Message, Theme, Ren
 where
     T: 'a + Display + FromStr + Clone + PartialEq,
     Message: 'a + Clone,
-    Renderer: 'a + iced::advanced::text::Renderer,
+    Renderer: 'a + iced_core::text::Renderer,
     Theme: 'a + text_input::Catalog,
 {
     fn from(typed_input: TypedInput<'a, T, Message, Theme, Renderer>) -> Self {

--- a/src/widget/wrap.rs
+++ b/src/widget/wrap.rs
@@ -1,21 +1,25 @@
 //! A widget that displays its children in multiple horizontal or vertical runs.
 //!
 //! *This API requires the following crate features to be activated: `wrap`*
-use iced::{
-    advanced::{
-        layout::{Limits, Node},
-        overlay, renderer,
-        widget::{Operation, Tree},
-        Clipboard, Layout, Shell, Widget,
-    },
+use iced_core::{
+    layout::{Limits, Node},
     mouse::{self, Cursor},
-    Alignment, Element, Event, Length, Padding, Pixels, Point, Rectangle, Size, Vector,
+    overlay, renderer,
+    widget::{Operation, Tree},
+    Alignment, Clipboard, Element, Event, Layout, Length, Padding, Pixels, Point, Rectangle, Shell,
+    Size, Vector, Widget,
 };
 use std::marker::PhantomData;
 
 /// A container that distributes its contents horizontally.
 #[allow(missing_debug_implementations)]
-pub struct Wrap<'a, Message, Direction, Theme = iced::Theme, Renderer = iced::Renderer> {
+pub struct Wrap<
+    'a,
+    Message,
+    Direction,
+    Theme = iced_widget::Theme,
+    Renderer = iced_widget::Renderer,
+> {
     /// The elements to distribute.
     pub elements: Vec<Element<'a, Message, Theme, Renderer>>,
     /// The alignment of the [`Wrap`].


### PR DESCRIPTION
Importing iced directly could cause issues when we disable some default features that were causing panic (like mundy) and it would be pulled via iced_aw when it's wasn't needed in the first place for a widget crate.

It could be nice to homogenise the import style across the widgets tho.