### PR TITLE
Added code coverage configuration file

### DIFF
--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,6 @@
+[tarpaulin]
+out = ["Html", "Xml", "Markdown"]
+output-dir = "target/tarpaulin"
+exclude-files = ["examples/*", "tests/*"]
+skip-clean = true
+timeout = "5m"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
-# Integration Tests Guide
+# Code Integration Testing Guide
 
-This directory contains integration tests for `iced_aw` widgets using the `iced_test` simulator framework.
+Code integration testing is the practice of testing how different modules, components, or services work together. This directory contains integration tests for `iced_aw` widgets using the `iced_test` simulator framework.
 
 ## Quick Start
 
@@ -327,3 +327,11 @@ Common icon characters used in widgets (searchable with `ui.find()`):
 - `\u{e805}` - ok (checkmark/submit)
 
 Or search for their display forms: `" ▲ "`, `" ▼ "`, `" ✓ "`, etc.
+
+# Code Coverage
+
+It is suggested that integration testing prioritize critical paths and common failure points rather than exhaustive coverage.  Coverage configuration found at `tarpaulin.toml`.
+
+```bash
+cargo tarpaulin
+```

--- a/tests/date_picker_integration_tests.rs
+++ b/tests/date_picker_integration_tests.rs
@@ -66,6 +66,7 @@ fn date_picker_can_find_underlay_button_text() -> Result<(), Error> {
 #[test]
 fn date_picker_underlay_button_opens_picker() -> Result<(), Error> {
     let date = Date::from_ymd(2024, 6, 15);
+    #[allow(unused_assignments)]
     let mut show_picker = false;
 
     let (mut app, _) = App::new(move || {

--- a/tests/time_picker_integration_tests.rs
+++ b/tests/time_picker_integration_tests.rs
@@ -77,6 +77,7 @@ fn time_picker_underlay_button_opens_picker() -> Result<(), Error> {
         minute: 30,
         period: Period::H24,
     };
+    #[allow(unused_assignments)]
     let mut show_picker = false;
 
     let (mut app, _) = App::new(move || {


### PR DESCRIPTION
### Summary

This is a small PR dealing with code coverage.  

- I've added `tarpaulin.toml` to configure code coverage runs, and updated the testing guidelines with a code coverage section.
- As of my most recent analysis, code coverage is sitting at about 44% lines covered.  As I state in the testing guide (`tests/README.md`), it is suggested that integration testing prioritize critical paths and common failure points rather than exhaustive coverage.  But metrics help us to know where we stand, so at any time detailed coverage reports can be seen in the `target/tarpaulin` folder after running:

```bash
cargo tarpaulin
```  