### PR TITLE
TabBar: Add a border radius to the tab Style

### DIFF
--- a/src/style/tab_bar.rs
+++ b/src/style/tab_bar.rs
@@ -21,6 +21,9 @@ pub struct Style {
     /// The border width of the tab bar.
     pub border_width: f32,
 
+    /// The border radius of a tab.
+    pub tab_border_radius: Radius,
+
     /// The background of the tab labels.
     pub tab_label_background: Background,
 
@@ -49,6 +52,7 @@ impl Default for Style {
             background: None,
             border_color: None,
             border_width: 0.0,
+            tab_border_radius: Radius::default(),
             tab_label_background: Background::Color([0.87, 0.87, 0.87].into()),
             tab_label_border_color: [0.7, 0.7, 0.7].into(),
             tab_label_border_width: 1.0,

--- a/src/widget/tab_bar.rs
+++ b/src/widget/tab_bar.rs
@@ -859,7 +859,7 @@ fn draw_tab<Theme, Renderer>(
             renderer::Quad {
                 bounds,
                 border: Border {
-                    radius: (0.0).into(),
+                    radius: style.tab_border_radius,
                     width: style.tab_label_border_width,
                     color: style.tab_label_border_color,
                 },


### PR DESCRIPTION
Add the ability to style the border radius of tabs.

<img width="1026" height="200" alt="grafik" src="https://github.com/user-attachments/assets/b23871d0-ccc9-486d-8ae1-af3cf0d5373d" />
