### PR TITLE
Reduced the lifetime from 'static to 'a for the on_change function of NumberInput

### DIFF
--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -296,8 +296,8 @@ where
     Message: Clone + 'a,
     Renderer: iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: crate::style::number_input::ExtendedCatalog,
-    F: 'static + Fn(T) -> Message + Copy,
-    T: 'static
+    F: 'a + Fn(T) -> Message + Copy,
+    T: 'a
         + num_traits::Num
         + num_traits::NumAssignOps
         + PartialOrd

--- a/src/widget/number_input.rs
+++ b/src/widget/number_input.rs
@@ -120,8 +120,7 @@ where
     /// - a function that produces a message when the [`NumberInput`] changes
     pub fn new<F>(value: &T, bounds: impl RangeBounds<T>, on_change: F) -> Self
     where
-        F: 'static + Fn(T) -> Message + Clone,
-        T: 'static,
+        F: 'a + Fn(T) -> Message + Clone,
     {
         let padding = DEFAULT_PADDING;
 


### PR DESCRIPTION
First the lifetime didn't need to be 'static. 

However my main reason for this is I was using the slider widget multiple times on a page so I created a structure that wrapped the slider to do all the common code between all the slider instances.  This means that the on_change function I was passing in is already a Box<dyn Fn(u32) -> Message> with a lifetime tied to the structure, NOT static.  So when I was trying to switch from using a slider to the number_input the compiler won't let me because of lifetimes.

This is my structure:
```
pub struct NumericInput {
    initial:        u32,
    current:        u32,
    max:            u32,
    label:          String,
    on_change:      Box<dyn Fn(u32) -> Message>
}
```

And the code to generate the control in the UI is:

```
fn control<'a>(&'a self) -> Element<'a, Message> {
    row![
        space().width(24.0),
        text(&self.label).width(152.0),
        space().width(8.0),
        NumberInput::new(&self.current, 0..=self.max, &self.on_change)
    ].into()
}
```
However this failed because &self.on_change needed to have a 'static lifetime. By updating iced_aw's NumberInput so that on_change argument now has a lifetime of 'a instead of 'static the compiler is happy and I'm not constrained by the on_change function.
