### PR TITLE
Scope `menu_items` macro

### DIFF
--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -128,7 +128,7 @@ macro_rules! menu {
 #[macro_export]
 macro_rules! menu_bar {
     ($($input:tt)+) => (
-        $crate::menu::MenuBar::new(menu_items!( $($input)+ ))
+        $crate::menu::MenuBar::new($crate::menu_items!( $($input)+ ))
     );
 }
 


### PR DESCRIPTION
Scopes `menu_items` macro in `menu_bar` so users don't need to manually import it.