### PR TITLE
Remove unused cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ features = ["tokio", "advanced"]
 iced_core = { version = "0.14.0" }
 iced_widget = { version = "0.14.2" }
 
-cfg-if = "1.0"
 chrono = { version = "0.4.44", optional = true, features = ["wasmbind"] }
 iced_fonts = { version = "0.3.0", features = [
   "advanced_text",


### PR DESCRIPTION
Closes #428.

`cfg-if` is declared as a direct dependency but isn't referenced anywhere in the crate, so this just drops it from `Cargo.toml`. `cargo check --features full` still builds cleanly. The `rust-version` is already 1.88, so no MSRV change is needed.