### PR TITLE
selection_list: accept Borrow<[T]> instead of &[T] for options

### DIFF
--- a/src/widget/helpers.rs
+++ b/src/widget/helpers.rs
@@ -333,15 +333,15 @@ where
 ///
 /// [`SelectionList`]: crate::SelectionList
 #[must_use]
-pub fn selection_list_with<'a, T, Message, Theme, Renderer>(
-    options: &'a [T],
+pub fn selection_list_with<'a, T, L, Message, Theme, Renderer>(
+    options: L,
     on_selected: impl Fn(usize, T) -> Message + 'static,
     text_size: f32,
     padding: impl Into<Padding>,
-    style: impl Fn(&Theme, Status) -> crate::style::selection_list::Style + 'a + Clone,
+    style: impl Fn(&Theme, Status) -> crate::style::selection_list::Style + 'a,
     selected: Option<usize>,
     font: iced_core::Font,
-) -> crate::SelectionList<'a, T, Message, Theme, Renderer>
+) -> crate::SelectionList<'a, T, L, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
     Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
@@ -351,6 +351,7 @@ where
         + iced_widget::scrollable::Catalog
         + iced_widget::text::Catalog,
     T: Clone + Display + Eq + Hash,
+    L: std::borrow::Borrow<[T]>,
     [T]: ToOwned<Owned = Vec<T>>,
     <Theme as crate::style::selection_list::Catalog>::Class<'a>:
         From<StyleFn<'a, Theme, crate::style::selection_list::Style>>,
@@ -371,10 +372,10 @@ where
 ///
 /// [`SelectionList`]: crate::SelectionList
 #[must_use]
-pub fn selection_list<'a, T, Message, Theme, Renderer>(
-    options: &'a [T],
+pub fn selection_list<'a, T, L, Message, Theme, Renderer>(
+    options: L,
     on_selected: impl Fn(usize, T) -> Message + 'static,
-) -> crate::SelectionList<'a, T, Message, Theme, Renderer>
+) -> crate::SelectionList<'a, T, L, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
     Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
@@ -384,6 +385,7 @@ where
         + iced_widget::scrollable::Catalog
         + iced_widget::text::Catalog,
     T: Clone + Display + Eq + Hash,
+    L: std::borrow::Borrow<[T]>,
     [T]: ToOwned<Owned = Vec<T>>,
 {
     crate::SelectionList::new(options, on_selected)

--- a/src/widget/selection_list.rs
+++ b/src/widget/selection_list.rs
@@ -18,7 +18,7 @@ use iced_widget::{
     Container, Scrollable, container, scrollable,
     text::{self, LineHeight, Wrapping},
 };
-use std::{fmt::Display, hash::Hash, marker::PhantomData};
+use std::{borrow::Borrow, fmt::Display, hash::Hash, marker::PhantomData};
 
 pub use list::List;
 
@@ -28,19 +28,23 @@ pub use list::List;
 pub struct SelectionList<
     'a,
     T,
+    L,
     Message,
     Theme = iced_widget::Theme,
     Renderer = iced_widget::Renderer,
 > where
     T: Clone + ToString + Eq + Hash,
+    L: Borrow<[T]>,
     [T]: ToOwned<Owned = Vec<T>>,
     Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: Catalog + container::Catalog,
 {
-    /// Container for Rendering List.
-    container: Container<'a, Message, Theme, Renderer>,
     /// List of Elements to Render.
-    options: &'a [T],
+    options: L,
+    /// Function Pointer On Select to call on Mouse button press.
+    on_selected: Box<dyn Fn(usize, T) -> Message>,
+    /// Set the Selected ID manually.
+    selected: Option<usize>,
     /// Label Font
     font: Renderer::Font,
     /// The Containers Width
@@ -53,43 +57,36 @@ pub struct SelectionList<
     text_size: f32,
     /// Style for Looks
     class: <Theme as Catalog>::Class<'a>,
+    /// Marker to hold the lifetime and type parameters.
+    phantomdata: PhantomData<&'a T>,
 }
 
 #[allow(clippy::type_repetition_in_bounds)]
-impl<'a, T, Message, Theme, Renderer> SelectionList<'a, T, Message, Theme, Renderer>
+impl<'a, T, L, Message, Theme, Renderer> SelectionList<'a, T, L, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
     Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + container::Catalog + scrollable::Catalog + iced_widget::text::Catalog,
     T: Clone + Display + Eq + Hash,
+    L: Borrow<[T]>,
     [T]: ToOwned<Owned = Vec<T>>,
 {
     /// Creates a new [`SelectionList`] with the given list of `options`,
     /// the current selected value, and the `message` to produce when an option is
     /// selected. This will default the `style`, `text_size` and `padding`. use `new_with`
     /// to set those.
-    pub fn new(options: &'a [T], on_selected: impl Fn(usize, T) -> Message + 'static) -> Self {
-        let container = Container::new(Scrollable::new(List {
-            options,
-            font: Font::default(),
-            text_size: 12.0,
-            padding: 5.0.into(),
-            class: <Theme as Catalog>::default(),
-            on_selected: Box::new(on_selected),
-            selected: None,
-            phantomdata: PhantomData,
-        }))
-        .padding(1);
-
+    pub fn new(options: L, on_selected: impl Fn(usize, T) -> Message + 'static) -> Self {
         Self {
             options,
+            on_selected: Box::new(on_selected),
+            selected: None,
             font: Font::default(),
             class: <Theme as Catalog>::default(),
-            container,
             width: Length::Fill,
             height: Length::Fill,
             padding: 5.0.into(),
             text_size: 12.0,
+            phantomdata: PhantomData,
         }
     }
 
@@ -97,11 +94,11 @@ where
     /// the current selected value, the message to produce when an option is
     /// selected, the `style`, `text_size`, `padding` and `font`.
     pub fn new_with(
-        options: &'a [T],
+        options: L,
         on_selected: impl Fn(usize, T) -> Message + 'static,
         text_size: f32,
         padding: impl Into<Padding>,
-        style: impl Fn(&Theme, Status) -> Style + 'a + Clone,
+        style: impl Fn(&Theme, Status) -> Style + 'a,
         selected: Option<usize>,
         font: Font,
     ) -> Self
@@ -109,34 +106,37 @@ where
         <Theme as Catalog>::Class<'a>: From<StyleFn<'a, Theme, Style>>,
     {
         let class: <Theme as Catalog>::Class<'a> =
-            (Box::new(style.clone()) as StyleFn<'a, Theme, Style>).into();
-        let class2: <Theme as Catalog>::Class<'a> =
             (Box::new(style) as StyleFn<'a, Theme, Style>).into();
 
         let padding = padding.into();
 
-        let container = Container::new(Scrollable::new(List {
-            options,
-            font,
-            text_size,
-            padding,
-            class: class2,
-            selected,
-            on_selected: Box::new(on_selected),
-            phantomdata: PhantomData,
-        }))
-        .padding(1);
-
         Self {
             options,
+            on_selected: Box::new(on_selected),
+            selected,
             font,
             class,
-            container,
             width: Length::Fill,
             height: Length::Fill,
             padding,
             text_size,
+            phantomdata: PhantomData,
         }
+    }
+
+    /// Builds the internal scrollable list container from the current options.
+    fn list_container(&self) -> Container<'_, Message, Theme, Renderer> {
+        Container::new(Scrollable::new(List {
+            options: self.options.borrow(),
+            font: self.font,
+            text_size: self.text_size,
+            padding: self.padding,
+            class: &self.class,
+            on_selected: self.on_selected.as_ref(),
+            selected: self.selected,
+            phantomdata: PhantomData,
+        }))
+        .padding(1)
     }
 
     /// Sets the width of the [`SelectionList`].
@@ -171,21 +171,22 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for SelectionList<'a, T, Message, Theme, Renderer>
+impl<'a, T, L, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for SelectionList<'a, T, L, Message, Theme, Renderer>
 where
     T: 'a + Clone + ToString + Eq + Hash + Display,
-    Message: 'static,
+    L: Borrow<[T]>,
+    Message: 'static + Clone,
     Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font> + 'a,
-    Theme: Catalog + container::Catalog,
+    Theme: Catalog + container::Catalog + scrollable::Catalog + iced_widget::text::Catalog + 'a,
 {
     fn diff(&mut self, tree: &mut Tree) {
-        tree.diff_children(&mut [&mut self.container as &mut dyn Widget<_, _, _>]);
+        tree.diff_children(&mut [&mut self.list_container() as &mut dyn Widget<_, _, _>]);
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
-        if state.values.len() != self.options.len() {
-            state.values = self
-                .options
+        let options = self.options.borrow();
+        if state.values.len() != options.len() {
+            state.values = options
                 .iter()
                 .map(|_| paragraph::Plain::<Renderer::Paragraph>::default())
                 .collect();
@@ -201,7 +202,7 @@ where
     }
 
     fn state(&self) -> tree::State {
-        tree::State::new(State::<Renderer::Paragraph>::new(self.options))
+        tree::State::new(State::<Renderer::Paragraph>::new(self.options.borrow()))
     }
 
     fn layout(&mut self, tree: &mut Tree, renderer: &Renderer, limits: &Limits) -> Node {
@@ -214,6 +215,7 @@ where
         let max_width = match self.width {
             Length::Shrink => self
                 .options
+                .borrow()
                 .iter()
                 .enumerate()
                 .map(|(id, val)| {
@@ -243,7 +245,7 @@ where
         let limits = limits.width(self.width.max(max_width as f32 + self.padding.x()));
 
         let content = self
-            .container
+            .list_container()
             .layout(&mut tree.children[0], renderer, &limits);
         let size = limits.resolve(self.width, self.height, content.size());
         Node::with_children(size, vec![content])
@@ -259,7 +261,7 @@ where
         shell: &mut Shell<Message>,
         viewport: &Rectangle,
     ) {
-        self.container.update(
+        self.list_container().update(
             &mut state.children[0],
             event,
             layout
@@ -281,8 +283,13 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.container
-            .mouse_interaction(&state.children[0], layout, cursor, viewport, renderer)
+        self.list_container().mouse_interaction(
+            &state.children[0],
+            layout,
+            cursor,
+            viewport,
+            renderer,
+        )
     }
 
     fn draw(
@@ -312,7 +319,7 @@ where
                 style_sheet.background,
             );
 
-            self.container.draw(
+            self.list_container().draw(
                 &state.children[0],
                 renderer,
                 theme,
@@ -335,7 +342,7 @@ where
         operation: &mut dyn iced_core::widget::Operation<()>,
     ) {
         Widget::<Message, Theme, Renderer>::operate(
-            &mut self.container,
+            &mut self.list_container(),
             &mut state.children[0],
             layout
                 .children()
@@ -347,15 +354,16 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer> From<SelectionList<'a, T, Message, Theme, Renderer>>
+impl<'a, T, L, Message, Theme, Renderer> From<SelectionList<'a, T, L, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
-    T: Clone + ToString + Eq + Hash + Display,
-    Message: 'static,
+    T: 'a + Clone + ToString + Eq + Hash + Display,
+    L: 'a + Borrow<[T]>,
+    Message: 'static + Clone,
     Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
-    Theme: 'a + Catalog + container::Catalog,
+    Theme: 'a + Catalog + container::Catalog + scrollable::Catalog + iced_widget::text::Catalog,
 {
-    fn from(selection_list: SelectionList<'a, T, Message, Theme, Renderer>) -> Self {
+    fn from(selection_list: SelectionList<'a, T, L, Message, Theme, Renderer>) -> Self {
         Element::new(selection_list)
     }
 }
@@ -392,7 +400,8 @@ mod tests {
         Selected(usize, String),
     }
 
-    type TestSelectionList<'a> = SelectionList<'a, String, TestMessage, iced_widget::Theme>;
+    type TestSelectionList<'a> =
+        SelectionList<'a, String, &'a [String], TestMessage, iced_widget::Theme>;
 
     #[test]
     fn selection_list_new_creates_instance() {
@@ -502,6 +511,27 @@ mod tests {
         assert_eq!(selection_list.options[0], "Option 1");
         assert_eq!(selection_list.options[1], "Option 2");
         assert_eq!(selection_list.options[2], "Option 3");
+    }
+
+    #[test]
+    fn selection_list_accepts_owned_vec() {
+        // Regression test for #411: `options` should accept a `Borrow<[T]>`,
+        // so an owned `Vec<T>` produced inline (e.g. inside a `view` method)
+        // works without needing a value that outlives the widget.
+        fn build_options() -> Vec<String> {
+            vec!["Option 1".to_owned(), "Option 2".to_owned()]
+        }
+
+        let selection_list: SelectionList<
+            '_,
+            String,
+            Vec<String>,
+            TestMessage,
+            iced_widget::Theme,
+        > = SelectionList::new(build_options(), TestMessage::Selected);
+
+        assert_eq!(selection_list.options.len(), 2);
+        assert_eq!(selection_list.options[0], "Option 1");
     }
 
     #[test]

--- a/src/widget/selection_list/list.rs
+++ b/src/widget/selection_list/list.rs
@@ -24,7 +24,7 @@ use std::{
 
 /// The Private [`List`] Handles the Actual list rendering.
 #[allow(missing_debug_implementations)]
-pub struct List<'a, T: 'a, Message, Theme, Renderer>
+pub struct List<'a, 'c, T: 'a, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
     [T]: ToOwned<Owned = Vec<T>>,
@@ -37,9 +37,9 @@ where
     /// Label Font
     pub font: Renderer::Font,
     /// Style for Font colors and Box hover colors.
-    pub class: <Theme as Catalog>::Class<'a>,
+    pub class: &'a <Theme as Catalog>::Class<'c>,
     /// Function Pointer On Select to call on Mouse button press.
-    pub on_selected: Box<dyn Fn(usize, T) -> Message>,
+    pub on_selected: &'a dyn Fn(usize, T) -> Message,
     /// The padding Width
     pub padding: Padding,
     /// The Text Size
@@ -62,7 +62,7 @@ pub struct ListState {
 }
 
 impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for List<'_, T, Message, Theme, Renderer>
+    for List<'_, '_, T, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
     Renderer: renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
@@ -234,27 +234,23 @@ where
                         ..renderer::Quad::default()
                     },
                     if is_selected {
-                        <Theme as Catalog>::style(
-                            theme,
-                            &self.class,
-                            crate::style::Status::Selected,
-                        )
-                        .background
+                        <Theme as Catalog>::style(theme, self.class, crate::style::Status::Selected)
+                            .background
                     } else {
-                        <Theme as Catalog>::style(theme, &self.class, crate::style::Status::Hovered)
+                        <Theme as Catalog>::style(theme, self.class, crate::style::Status::Hovered)
                             .background
                     },
                 );
             }
 
             let text_color = if is_selected {
-                <Theme as Catalog>::style(theme, &self.class, crate::style::Status::Selected)
+                <Theme as Catalog>::style(theme, self.class, crate::style::Status::Selected)
                     .text_color
             } else if is_hovered {
-                <Theme as Catalog>::style(theme, &self.class, crate::style::Status::Hovered)
+                <Theme as Catalog>::style(theme, self.class, crate::style::Status::Hovered)
                     .text_color
             } else {
-                <Theme as Catalog>::style(theme, &self.class, crate::style::Status::Active)
+                <Theme as Catalog>::style(theme, self.class, crate::style::Status::Active)
                     .text_color
             };
 
@@ -315,15 +311,16 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer> From<List<'a, T, Message, Theme, Renderer>>
+impl<'a, 'c, T, Message, Theme, Renderer> From<List<'a, 'c, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Clone + Display + Eq + Hash,
+    'c: 'a,
     Message: 'a,
     Renderer: 'a + renderer::Renderer + iced_core::text::Renderer<Font = iced_core::Font>,
     Theme: 'a + Catalog + iced_widget::text::Catalog,
 {
-    fn from(list: List<'a, T, Message, Theme, Renderer>) -> Self {
+    fn from(list: List<'a, 'c, T, Message, Theme, Renderer>) -> Self {
         Element::new(list)
     }
 }


### PR DESCRIPTION
## Summary

Closes #411.

`SelectionList` currently takes `options: &'a [T]`, which forces callers to store the options with the same lifetime as their app state — unlike `PickList`, which already takes `L: Borrow<[T]>` and happily accepts an owned `Vec<T>` built inline in `view()`.

This mirrors that same pattern for `SelectionList`:
- `SelectionList<'a, T, L, Message, Theme, Renderer>` is now generic over `L: Borrow<[T]>`.
- The previous implementation eagerly built and cached a `Container<Scrollable<List>>` once at construction time, embedding the borrowed `&'a [T]` into it directly — exactly the constraint the issue wants removed. Since `options` is now an owned `L`, that can no longer be pre-built and cached (the inner `List` widget needs a live `&[T]`, not an owned `L`).
- Restructured so the container is rebuilt on demand from a private `list_container()` helper, called from each `Widget` trait method (`diff`/`layout`/`update`/`mouse_interaction`/`draw`/`operate`) — the same pattern `PickList` already uses for its menu overlay.
- The internal `List` widget now takes `class` and `on_selected` by reference rather than by value, since they're borrowed from `SelectionList`'s own fields on each call instead of being moved in once at construction.
- `widget::helpers::selection_list[_with]` updated to thread the new `L` parameter through.
- Added a regression test (`selection_list_accepts_owned_vec`) that builds an owned `Vec<String>` inline and constructs a `SelectionList` from it directly, proving the actual use case from the issue.

## Test plan
- [x] `cargo test --features selection_list --lib selection_list` — all 25 unit tests pass, including the new owned-`Vec` regression test
- [x] `cargo clippy --all-features --lib --tests --bins` — no new warnings (same 5 pre-existing warnings in unrelated widgets: card, tabs, sidebar, menu_bar)
- [x] `cargo test --all --all-features --lib --tests --bins` — all `selection_list` integration tests pass except `selection_list_can_find_all_options_in_list`, a snapshot-diff test; confirmed this is **pre-existing environment flakiness** by reproducing the identical failure against the unmodified `main` baseline, and by observing 10 other unrelated widgets' snapshot tests (badge, card, color_picker, date_picker, number_input, sidebar, tab_bar, time_picker, wrap, etc.) fail the same way in this environment
- [x] `cargo build --example selection_list --features selection_list` — existing example builds unmodified, confirming the common `&[T]` usage still infers `L` correctly with no call-site changes needed
- [x] `cargo fmt --check` — clean